### PR TITLE
Animated physicals + no clamped stencils

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -166,7 +166,7 @@ class MaterialConverter:
         if slot.use_stencil:
             hsgmat.compFlags |= hsGMaterial.kCompNeedsBlendChannel
             state.blendFlags |= hsGMatState.kBlendAlpha | hsGMatState.kBlendAlphaMult | hsGMatState.kBlendNoTexColor
-            if slot.texture and slot.texture.type == "BLEND":
+            if slot.texture.type == "BLEND":
                 state.clampFlags |= hsGMatState.kClampTexture
             state.ZFlags |= hsGMatState.kZNoZWrite
             layer.ambient = hsColorRGBA(1.0, 1.0, 1.0, 1.0)

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -166,7 +166,8 @@ class MaterialConverter:
         if slot.use_stencil:
             hsgmat.compFlags |= hsGMaterial.kCompNeedsBlendChannel
             state.blendFlags |= hsGMatState.kBlendAlpha | hsGMatState.kBlendAlphaMult | hsGMatState.kBlendNoTexColor
-            state.clampFlags |= hsGMatState.kClampTexture
+            if slot.texture and slot.texture.type == "BLEND":
+                state.clampFlags |= hsGMatState.kClampTexture
             state.ZFlags |= hsGMatState.kZNoZWrite
             layer.ambient = hsColorRGBA(1.0, 1.0, 1.0, 1.0)
 

--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -77,14 +77,6 @@ class PhysicsConverter:
             physical.sceneNode = self._mgr.get_scene_node(bl=bo)
 
             getattr(self, "_export_{}".format(bounds))(bo, physical)
-            
-            if self._exporter().has_coordiface(bo):
-                if not physical.mass:
-                    # ...Since the object has a coordinate interface but isn't a kickable, it's likely going to be animated. In such case,
-                    # we must warn Plasma to have the collisions follow the object's coordinates as well.
-                    physical.mass = 1.
-                    simIface.setProperty(plSimulationInterface.kPinned, True)
-                    physical.setProperty(plSimulationInterface.kPinned, True)
         else:
             simIface = so.sim.object
             physical = simIface.physical.object

--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -77,6 +77,14 @@ class PhysicsConverter:
             physical.sceneNode = self._mgr.get_scene_node(bl=bo)
 
             getattr(self, "_export_{}".format(bounds))(bo, physical)
+            
+            if self._exporter().has_coordiface(bo):
+                if not physical.mass:
+                    # ...Since the object has a coordinate interface but isn't a kickable, it's likely going to be animated. In such case,
+                    # we must warn Plasma to have the collisions follow the object's coordinates as well.
+                    physical.mass = 1.
+                    simIface.setProperty(plSimulationInterface.kPinned, True)
+                    physical.setProperty(plSimulationInterface.kPinned, True)
         else:
             simIface = so.sim.object
             physical = simIface.physical.object

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -130,12 +130,8 @@ class PlasmaAnimationModifier(PlasmaModifierProperties):
     @property
     def key_name(self):
         return "{}_(Entire Animation)".format(self.id_data.name)
-
-    def post_export(self, exporter, bo, so):
-        # If this object has a physical, we need to tell the simulation iface that it can be animated
-        self.make_physical_movable(so)
     
-    def make_physical_movable(self, so):
+    def __make_physical_movable(self, so):
         sim = so.sim
         if sim is not None:
             sim = sim.object
@@ -154,6 +150,10 @@ class PlasmaAnimationModifier(PlasmaModifierProperties):
         # Do the same for children objects
         for child in so.coord.object.children:
             self.make_physical_movable(child.object)
+
+    def post_export(self, exporter, bo, so):
+        # If this object has a physical, we need to tell the simulation iface that it can be animated
+        self.__make_physical_movable(so)
 
 
 class AnimGroupObject(bpy.types.PropertyGroup):

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -131,7 +131,7 @@ class PlasmaAnimationModifier(PlasmaModifierProperties):
     def key_name(self):
         return "{}_(Entire Animation)".format(self.id_data.name)
     
-    def __make_physical_movable(self, so):
+    def _make_physical_movable(self, so):
         sim = so.sim
         if sim is not None:
             sim = sim.object
@@ -153,7 +153,7 @@ class PlasmaAnimationModifier(PlasmaModifierProperties):
 
     def post_export(self, exporter, bo, so):
         # If this object has a physical, we need to tell the simulation iface that it can be animated
-        self.__make_physical_movable(so)
+        self._make_physical_movable(so)
 
 
 class AnimGroupObject(bpy.types.PropertyGroup):

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -143,6 +143,15 @@ class PlasmaAnimationModifier(PlasmaModifierProperties):
             # If the mass is zero, then we will fail to animate. Fix that.
             if phys.mass == 0.0:
                 phys.mass = 1.0
+                
+                # On CC and Prime, set kPinned so it doesn't fall through
+                if bpy.context.scene.world.plasma_age.version in ["pvPots", "pvPrime"]:
+                    sim.setProperty(plSimulationInterface.kPinned, True)
+                    phys.setProperty(plSimulationInterface.kPinned, True)
+        
+        # Do the same for children objects
+        for child in so.coord.object.children:
+            self.post_export(exporter, None, child.object)
 
 
 class AnimGroupObject(bpy.types.PropertyGroup):

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -133,6 +133,9 @@ class PlasmaAnimationModifier(PlasmaModifierProperties):
 
     def post_export(self, exporter, bo, so):
         # If this object has a physical, we need to tell the simulation iface that it can be animated
+        self.make_physical_movable(so)
+    
+    def make_physical_movable(self, so):
         sim = so.sim
         if sim is not None:
             sim = sim.object
@@ -144,14 +147,13 @@ class PlasmaAnimationModifier(PlasmaModifierProperties):
             if phys.mass == 0.0:
                 phys.mass = 1.0
                 
-                # On CC and Prime, set kPinned so it doesn't fall through
-                if bpy.context.scene.world.plasma_age.version in ["pvPots", "pvPrime"]:
-                    sim.setProperty(plSimulationInterface.kPinned, True)
-                    phys.setProperty(plSimulationInterface.kPinned, True)
+                # set kPinned so it doesn't fall through
+                sim.setProperty(plSimulationInterface.kPinned, True)
+                phys.setProperty(plSimulationInterface.kPinned, True)
         
         # Do the same for children objects
         for child in so.coord.object.children:
-            self.post_export(exporter, None, child.object)
+            self.make_physical_movable(child.object)
 
 
 class AnimGroupObject(bpy.types.PropertyGroup):


### PR DESCRIPTION
Set mass=1 and kPinned for non-kickable physicals having a CoordinateInterface, so they can be animated.
Don't force clamping for texture stencils, so they can be tiled if necessary.

More infos : [https://forum.guildofwriters.org/viewtopic.php?f=2&t=6574&p=69469#p69469](url)