### PR TITLE
Fix parsing of Python scripts which use variable Booleans.

### DIFF
--- a/korman/plasma_attributes.py
+++ b/korman/plasma_attributes.py
@@ -69,13 +69,13 @@ class PlasmaAttributeVisitor(ast.NodeVisitor):
         # with the respective constant values True or False.
         if node.id.lower() in  {"true", "false"}:
             return ast.literal_eval(node.id.capitalize())
-        return(node.id)
+        return node.id
 
     def visit_Num(self, node):
-        return(node.n)
+        return node.n
 
     def visit_Str(self, node):
-        return(node.s)
+        return node.s
 
     def visit_List(self, node):
         elts = []
@@ -90,7 +90,7 @@ class PlasmaAttributeVisitor(ast.NodeVisitor):
         return tuple(elts)
 
     def visit_NameConstant(self, node):
-        return(node.value)
+        return node.value
 
     def generic_visit(self, node):
         ast.NodeVisitor.generic_visit(self, node)

--- a/korman/plasma_attributes.py
+++ b/korman/plasma_attributes.py
@@ -65,6 +65,10 @@ class PlasmaAttributeVisitor(ast.NodeVisitor):
         return self.generic_visit(node)
 
     def visit_Name(self, node):
+        # Workaround for old Cyan scripts: replace variables named "true" or "false"
+        # with the respective constant values True or False.
+        if node.id.lower() in  {"true", "false"}:
+            return ast.literal_eval(node.id.capitalize())
         return(node.id)
 
     def visit_Num(self, node):
@@ -84,6 +88,9 @@ class PlasmaAttributeVisitor(ast.NodeVisitor):
         for x in node.elts:
             elts.append(self.visit(x))
         return tuple(elts)
+
+    def visit_NameConstant(self, node):
+        return(node.value)
 
     def generic_visit(self, node):
         ast.NodeVisitor.generic_visit(self, node)


### PR DESCRIPTION
Some of Cyan's old scripts predate Python supporting Booleans, which leaves us with variables where we expected constant values. This change intercepts these cases and replaces them, avoiding an exception in Korman when it tries to shove one of these strings into a boolean attribute.

Also included is a new visitor for proper name constants, support for which was added in Python 3.4.  This will allow future scripts to use them and be recognized correctly.