### PR TITLE
Fix backward lamp distance calculation

### DIFF
--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -162,7 +162,7 @@ class AnimationConverter:
         if distance_fcurve is not None:
             channel = plScalarControllerChannel()
             channel.controller = self.make_scalar_leaf_controller(distance_fcurve,
-                                                                  lambda x: x * 2 if lamp.use_sphere else x)
+                                                                  lambda x: x if lamp.use_sphere else x * 2)
             applicator = plOmniCutoffApplicator()
             applicator.channelName = name
             applicator.channel = channel
@@ -175,7 +175,7 @@ class AnimationConverter:
         elif falloff == "INVERSE_LINEAR":
             def convert_linear_atten(distance, energy):
                 intens = abs(energy[0])
-                atten_end = distance[0] * 2 if lamp.use_sphere else distance[0]
+                atten_end = distance[0] if lamp.use_sphere else distance[0] * 2
                 return light_converter.convert_attenuation_linear(intens, atten_end)
 
             keyframes = self._process_fcurves([distance_fcurve, energy_fcurve], convert_linear_atten,
@@ -190,7 +190,7 @@ class AnimationConverter:
         elif falloff == "INVERSE_SQUARE":
             def convert_quadratic_atten(distance, energy):
                 intens = abs(energy[0])
-                atten_end = distance[0] * 2 if lamp.use_sphere else distance[0]
+                atten_end = distance[0] if lamp.use_sphere else distance[0] * 2
                 return light_converter.convert_attenuation_quadratic(intens, atten_end)
 
             keyframes = self._process_fcurves([distance_fcurve, energy_fcurve], convert_quadratic_atten,

--- a/korman/exporter/rtlight.py
+++ b/korman/exporter/rtlight.py
@@ -65,7 +65,7 @@ class LightConverter:
 
     def convert_attenuation(self, lamp):
         intens = abs(lamp.energy)
-        attenEnd = lamp.distance * 2 if lamp.use_sphere else lamp.distance
+        attenEnd = lamp.distance if lamp.use_sphere else lamp.distance * 2
         return (intens, attenEnd)
 
     def convert_attenuation_linear(self, intensity, end):


### PR DESCRIPTION
When `use_sphere` is enabled, the lamp cutoff is at exactly the distance value. Otherwise, the distance value is the point at which the lamp intensity is half its starting value.

This probably doesn't match Blender 1-to-1, but it's closer to Blender's lighting logic than the existing `use_sphere` calculations.