### PR TITLE
fix animation exporter not being able to handle missing axes

### DIFF
--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -320,14 +320,15 @@ class AnimationConverter:
             scale = kwargs.get(scale_path)
 
             # Since only some position curves may be supplied, construct dict with all positions
-            # TODO: probably the same is needed for scale but I don't need it now!
             allpos = dict(enumerate(pos_default))
+            allscale = dict(enumerate(scale_default))
             allpos.update(pos)
+            allscale.update(scale)
 
             matrix = hsMatrix44()
             # Note: scale and pos are dicts, so we can't unpack
             matrix.setTranslate(hsVector3(allpos[0], allpos[1], allpos[2]))
-            matrix.setScale(hsVector3(scale[0], scale[1], scale[2]))
+            matrix.setScale(hsVector3(allscale[0], allscale[1], allscale[2]))
             return matrix
 
         fcurves = [i for i in fcurves if i.data_path == pos_path or i.data_path == scale_path]
@@ -672,7 +673,10 @@ class AnimationConverter:
                         continue
                     for i in range(chan_values):
                         if i not in chan_keyframes.values:
-                            fcurve = grouped_fcurves[chan][i]
+                            if i in grouped_fcurves[chan]:
+                                fcurve = grouped_fcurves[chan][i]
+                            else:
+                                fcurve = defaults[chan][i]
                             if isinstance(fcurve, bpy.types.FCurve):
                                 chan_keyframes.values[i] = fcurve.evaluate(chan_keyframes.frame_num_blender)
                             else:

--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -319,9 +319,14 @@ class AnimationConverter:
             pos = kwargs.get(pos_path)
             scale = kwargs.get(scale_path)
 
+            # Since only some position curves may be supplied, construct dict with all positions
+            # TODO: probably the same is needed for scale but I don't need it now!
+            allpos = dict(enumerate(pos_default))
+            allpos.update(pos)
+
             matrix = hsMatrix44()
             # Note: scale and pos are dicts, so we can't unpack
-            matrix.setTranslate(hsVector3(pos[0], pos[1], pos[2]))
+            matrix.setTranslate(hsVector3(allpos[0], allpos[1], allpos[2]))
             matrix.setScale(hsVector3(scale[0], scale[1], scale[2]))
             return matrix
 


### PR DESCRIPTION
I ran into this problem when animating a texture. Normally when setting keyframes, all axes of a transformation are keyed. However if only a subset of all axes is actually manipulated in the animation (and the rest left constant), the keyframes for the other axes can be removed. One reason to do so is to make it clear what aspects are being animated. For example, a water texture that only moves along its X axis does not need keyframes for its Y and Z axes.

In the original code, the assumption was made that all keyframes had X, Y and Z components. Thus an error was raised on line 324, where elements of a dict are accessed that do not exist. By making use of the `pos_default` parameter, these missing values can be filled in by the static values of these properties.