### PR TITLE
ID Datablock Properties

### DIFF
--- a/korman/__init__.py
+++ b/korman/__init__.py
@@ -22,7 +22,7 @@ from . import operators
 bl_info = {
     "name":        "Korman",
     "author":      "Guild of Writers",
-    "blender":     (2, 78, 0),
+    "blender":     (2, 79, 0),
     "location":    "File > Import-Export",
     "description": "Exporter for Cyan Worlds' Plasma Engine",
     "warning":     "beta",

--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -146,12 +146,9 @@ class LightBaker:
 
     def _generate_lightgroup(self, bo, user_lg=None):
         """Makes a new light group for the baking process that excludes all Plasma RT lamps"""
-
-        if user_lg is not None:
-            user_lg = bpy.data.groups.get(user_lg)
         shouldibake = (user_lg is not None and bool(user_lg.objects))
-
         mesh = bo.data
+
         for material in mesh.materials:
             if material is None:
                 # material is not assigned to this material... (why is this even a thing?)
@@ -245,7 +242,7 @@ class LightBaker:
         uv_textures = mesh.uv_textures
 
         # Create a special light group for baking
-        if not self._generate_lightgroup(bo, modifier.light_group):
+        if not self._generate_lightgroup(bo, modifier.lights):
             return False
 
         # We need to ensure that we bake onto the "BlahObject_LIGHTMAPGEN" image

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -476,11 +476,11 @@ class MaterialConverter:
         # Whoever wrote this PyHSPlasma binding didn't follow the convention. Sigh.
         visregions = []
         for region in texture.plasma_layer.vis_regions:
-            rgn = bpy.data.objects.get(region.region_name, None)
+            rgn = region.control_region
             if rgn is None:
-                raise ExportError("'{}': VisControl '{}' not found".format(texture.name, region.region_name))
+                raise ExportError("'{}': Has an invalid Visibility Control".format(texture.name))
             if not rgn.plasma_modifiers.visregion.enabled:
-                raise ExportError("'{}': '{}' is not a VisControl".format(texture.name, region.region_name))
+                raise ExportError("'{}': '{}' is not a VisControl".format(texture.name, rgn.name))
             visregions.append(self._mgr.find_create_key(plVisRegion, bl=rgn))
         pl_env.visRegions = visregions
 

--- a/korman/exporter/rtlight.py
+++ b/korman/exporter/rtlight.py
@@ -171,13 +171,11 @@ class LightConverter:
         sv_mod, sv_key = bo.plasma_modifiers.softvolume, None
         if sv_mod.enabled:
             sv_key = sv_mod.get_key(self._exporter())
-        elif rtlamp.soft_region:
-            sv_bo = bpy.data.objects.get(rtlamp.soft_region, None)
-            if sv_bo is None:
-                raise ExportError("'{}': Invalid object for Lamp soft volume '{}'".format(bo.name, rtlamp.soft_region))
+        elif rtlamp.lamp_region:
+            sv_bo = rtlamp.lamp_region
             sv_mod = sv_bo.plasma_modifiers.softvolume
             if not sv_mod.enabled:
-                raise ExportError("'{}': '{}' is not a SoftVolume".format(bo.name, rtlamp.soft_region))
+                raise ExportError("'{}': '{}' is not a SoftVolume".format(bo.name, sv_bo.name))
             sv_key = sv_mod.get_key(self._exporter())
         pl_light.softVolume = sv_key
 

--- a/korman/helpers.py
+++ b/korman/helpers.py
@@ -51,9 +51,9 @@ class TemporaryObject:
 def ensure_power_of_two(value):
     return pow(2, math.floor(math.log(value, 2)))
 
-def find_modifier(boname, modid):
-    """Given a Blender Object name, finds a given modifier and returns it or None"""
-    bo = bpy.data.objects.get(boname, None)
+
+def find_modifier(bo, modid):
+    """Given a Blender Object, finds a given modifier and returns it or None"""
     if bo is not None:
         # if they give us the wrong modid, it is a bug and an AttributeError
         return getattr(bo.plasma_modifiers, modid)

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -138,3 +138,20 @@ def poll_visregion_objects(self, value):
 
 def poll_envmap_textures(self, value):
     return isinstance(value, bpy.types.EnvironmentMapTexture)
+
+@bpy.app.handlers.persistent
+def _upgrade_node_trees(dummy):
+    """
+    Logic node haxxor incoming!
+    Logic nodes appear to have issues with silently updating themselves. I expect that Blender is
+    doing something strange in the UI code that causes our metaprogramming tricks to be bypassed.
+    Therefore, we will loop through all Plasma node trees and forcibly update them on blend load.
+    """
+
+    for tree in bpy.data.node_groups:
+        if tree.bl_idname != "PlasmaNodeTree":
+            continue
+        for node in tree.nodes:
+            if isinstance(node, IDPropMixin):
+                assert node._try_upgrade_idprops()
+bpy.app.handlers.load_post.append(_upgrade_node_trees)

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -116,3 +116,13 @@ class IDPropObjectMixin(IDPropMixin):
         cls = object.__getattribute__(self, "__class__")
         idprops = cls._idprop_mapping()
         return { i: bpy.data.objects for i in idprops.values() }
+
+
+def poll_empty_objects(self, value):
+    return value.type == "EMPTY"
+
+def poll_mesh_objects(self, value):
+    return value.type == "MESH"
+
+def poll_envmap_textures(self, value):
+    return isinstance(value, bpy.types.EnvironmentMapTexture)

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -118,6 +118,12 @@ class IDPropObjectMixin(IDPropMixin):
         return { i: bpy.data.objects for i in idprops.values() }
 
 
+def poll_animated_objects(self, value):
+    if value.animation_data is not None:
+        if value.animation_data.action is not None:
+            return True
+    return False
+
 def poll_empty_objects(self, value):
     return value.type == "EMPTY"
 

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -133,5 +133,8 @@ def poll_mesh_objects(self, value):
 def poll_softvolume_objects(self, value):
     return value.plasma_modifiers.softvolume.enabled
 
+def poll_visregion_objects(self, value):
+    return value.plasma_modifiers.visregion.enabled
+
 def poll_envmap_textures(self, value):
     return isinstance(value, bpy.types.EnvironmentMapTexture)

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -1,0 +1,118 @@
+#    This file is part of Korman.
+#
+#    Korman is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Korman is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
+
+import bpy
+from bpy.props import *
+
+class IDPropMixin:
+    """
+    So, here's the rub.
+
+    In Blender 2.79, we finally get the ability to use native Blender ID Datablock properties in Python.
+    This is great! It will allow us to specify other objects (Blender Objects, Materials, Textures) in
+    our plugin as pointer properties. Further, we can even specify a poll method to create a 'search list'
+    of valid options.
+
+    Naturally, there are some cons. The con here is that we've been storing object NAMES in string properties
+    for several releases now. Therefore, the purpose of this class is simple... It is a mixin to be
+    used for silently upgrading these object name properties to ID Properties. You will need to override
+    the _idprop_mapping and _idprop_sources methods in your class. The mixin will handle upgrading
+    the properties when a derived class is touched.
+
+    Unfortunately, it is not possible to easily batch convert everything on load or save, due to issues
+    in the way Blender's Python API functions. Long story short: PropertyGroups do not execute __new__
+    or __init__. Furthermore, Blender's UI does not appreciate having ID Datablocks return from
+    __getattribute__. To make matters worse, all properties are locked in a read-only state during
+    the UI draw stage.
+    """
+
+    def __getattribute__(self, attr):
+        _getattribute = super().__getattribute__
+
+        # Let's make sure no one is trying to access an old version...
+        if attr in _getattribute("_idprop_mapping")().values():
+            raise AttributeError("'{}' has been deprecated... Please use the ID Property".format(attr))
+
+        # I have some bad news for you... Unfortunately, this might have been called
+        # during Blender's draw() context. Blender locks all properties during the draw loop.
+        # HOWEVER!!! There is a solution. Upon inspection of the Blender source code, however, it
+        # appears this restriction is temporarily suppressed during property getters... So let's get
+        # a property that executes a getter :D
+        # ...
+        # ...
+        # But why not simply proxy requests here, you ask? Ah, young grasshopper... This is the
+        # fifth time I have (re-)written this code. Trust me when I say, 'tis a boondoggle.
+        assert _getattribute("idprops_upgraded")
+
+        # Must be something regular. Just super it.
+        return super().__getattribute__(attr)
+
+    def __setattr__(self, attr, value):
+        idprops = super().__getattribute__("_idprop_mapping")()
+
+        # Disallow any attempts to set the old string property
+        if attr in idprops.values():
+            raise AttributeError("'{}' has been deprecated... Please use the ID Property".format(attr))
+
+        # Inappropriate touching?
+        super().__getattribute__("_try_upgrade_idprops")()
+
+        # Now, pass along our update
+        super().__setattr__(attr, value)
+
+    @classmethod
+    def register(cls):
+        if hasattr(super(), "register"):
+            super().register()
+
+        cls.idprops_upgraded = BoolProperty(name="INTERNAL: ID Property Upgrader HACK",
+                                            description="HAAAX *throws CRT monitor*",
+                                            get=cls._try_upgrade_idprops,
+                                            options={"HIDDEN"})
+        cls.idprops_upgraded_value = BoolProperty(name="INTERNAL: ID Property Upgrade Status",
+                                                  description="Have old StringProperties been upgraded to ID Datablock Properties?",
+                                                  default=False,
+                                                  options={"HIDDEN"})
+        for str_prop in cls._idprop_mapping().values():
+            setattr(cls, str_prop, StringProperty(description="deprecated"))
+
+    def _try_upgrade_idprops(self):
+        _getattribute = super().__getattribute__
+
+        if not _getattribute("idprops_upgraded_value"):
+            idprop_map = _getattribute("_idprop_mapping")()
+            strprop_src = _getattribute("_idprop_sources")()
+
+            for idprop_name, strprop_name in idprop_map.items():
+                if not super().is_property_set(strprop_name):
+                    continue
+                strprop_value = _getattribute(strprop_name)
+                idprop_value = strprop_src[strprop_name].get(strprop_value, None)
+                super().__setattr__(idprop_name, idprop_value)
+                super().property_unset(strprop_name)
+            super().__setattr__("idprops_upgraded_value", True)
+
+        # you should feel like this now... https://youtu.be/1JBSs6MQJeI?t=33s
+        return True
+
+
+class IDPropObjectMixin(IDPropMixin):
+    """Like IDPropMixin, but with the assumption that all IDs can be found in bpy.data.objects"""
+
+    def _idprop_sources(self):
+        # NOTE: bad problems result when using super() here, so we'll manually reference object
+        cls = object.__getattribute__(self, "__class__")
+        idprops = cls._idprop_mapping()
+        return { i: bpy.data.objects for i in idprops.values() }

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -130,5 +130,8 @@ def poll_empty_objects(self, value):
 def poll_mesh_objects(self, value):
     return value.type == "MESH"
 
+def poll_softvolume_objects(self, value):
+    return value.plasma_modifiers.softvolume.enabled
+
 def poll_envmap_textures(self, value):
     return isinstance(value, bpy.types.EnvironmentMapTexture)

--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -44,7 +44,7 @@ class PlasmaMessageNode(PlasmaNodeBase):
         return False
 
 
-class PlasmaAnimCmdMsgNode(PlasmaMessageNode, bpy.types.Node):
+class PlasmaAnimCmdMsgNode(idprops.IDPropMixin, PlasmaMessageNode, bpy.types.Node):
     bl_category = "MSG"
     bl_idname = "PlasmaAnimCmdMsgNode"
     bl_label = "Animation Command"
@@ -55,12 +55,32 @@ class PlasmaAnimCmdMsgNode(PlasmaMessageNode, bpy.types.Node):
                              items=[("OBJECT", "Object", "Mesh Action"),
                                     ("TEXTURE", "Texture", "Texture Action")],
                              default="OBJECT")
-    object_name = StringProperty(name="Object",
-                                 description="Target object name")
-    material_name = StringProperty(name="Material",
-                                   description="Target material name")
-    texture_name = StringProperty(name="Texture",
-                                  description="Target texture slot name")
+
+    def _poll_material_textures(self, value):
+        if self.target_object is None:
+            return False
+        if self.target_material is None:
+            return False
+        return value.name in self.target_material.texture_slots
+
+    def _poll_mesh_materials(self, value):
+        if self.target_object is None:
+            return False
+        if self.target_object.type != "MESH":
+            return False
+        return value.name in self.target_object.data.materials
+
+    target_object = PointerProperty(name="Object",
+                                    description="Target object",
+                                    type=bpy.types.Object)
+    target_material = PointerProperty(name="Material",
+                                      description="Target material",
+                                      type=bpy.types.Material,
+                                      poll=_poll_mesh_materials)
+    target_texture = PointerProperty(name="Texture",
+                                     description="Target texture",
+                                     type=bpy.types.Texture,
+                                     poll=_poll_material_textures)
 
     go_to = EnumProperty(name="Go To",
                          description="Where should the animation start?",
@@ -122,19 +142,16 @@ class PlasmaAnimCmdMsgNode(PlasmaMessageNode, bpy.types.Node):
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "anim_type")
-        layout.prop_search(self, "object_name", bpy.data, "objects")
+        layout.prop(self, "target_object")
 
         if self.anim_type != "OBJECT":
-            bo = bpy.data.objects.get(self.object_name)
-            if bo is None or not hasattr(bo.data, "materials"):
-                layout.label("Invalid Object", icon="ERROR")
-            else:
-                layout.prop_search(self, "material_name", bo.data, "materials")
-                material = bpy.data.materials.get(self.material_name, None)
-                if material is None:
-                    layout.label("Invalid Material", icon="ERROR")
-                else:
-                    layout.prop_search(self, "texture_name", material, "texture_slots")
+            col = layout.column()
+            col.enabled = self.target_object is not None
+            col.prop(self, "target_material")
+
+            col = layout.column()
+            col.enabled = self.target_object is not None and self.target_material is not None
+            col.prop(self, "target_texture")
 
         layout.prop(self, "go_to")
         layout.prop(self, "action")
@@ -150,8 +167,7 @@ class PlasmaAnimCmdMsgNode(PlasmaMessageNode, bpy.types.Node):
         if self.anim_type != "OBJECT":
             loops = None
         else:
-            obj = bpy.data.objects.get(self.object_name, None)
-            loops = None if obj is None else obj.plasma_modifiers.animation_loop
+            loops = None if self.target_object is None else self.target_object.plasma_modifiers.animation_loop
         if loops is not None and loops.enabled:
             layout.prop_search(self, "loop_name", loops, "loops", icon="PMARKER_ACT")
         else:
@@ -171,9 +187,9 @@ class PlasmaAnimCmdMsgNode(PlasmaMessageNode, bpy.types.Node):
         msg = plAnimCmdMsg()
 
         # We're either sending this off to an AGMasterMod or a LayerAnim
-        obj = bpy.data.objects.get(self.object_name, None)
+        obj = self.target_object
         if obj is None:
-            self.raise_error("invalid object: '{}'".format(self.object_name))
+            self.raise_error("target object must be specified")
         if self.anim_type == "OBJECT":
             if not obj.plasma_object.has_animation_data:
                 self.raise_error("invalid animation")
@@ -186,10 +202,13 @@ class PlasmaAnimCmdMsgNode(PlasmaMessageNode, bpy.types.Node):
             else:
                 _agmod_trash, target = exporter.animation.get_anigraph_keys(obj)
         else:
-            material = bpy.data.materials.get(self.material_name, None)
+            material = self.target_material
             if material is None:
-                self.raise_error("invalid material: '{}'".format(self.material_name))
-            target = exporter.mesh.material.get_texture_animation_key(obj, material, self.texture_name)
+                self.raise_error("target material must be specified")
+            texture = self.target_texture
+            if texture is None:
+                self.raise_error("target texture must be specified")
+            target = exporter.mesh.material.get_texture_animation_key(obj, material, texture)
 
         if target is None:
             raise RuntimeError()
@@ -224,6 +243,17 @@ class PlasmaAnimCmdMsgNode(PlasmaMessageNode, bpy.types.Node):
     @property
     def has_callbacks(self):
         return self.event != "NONE"
+
+    @classmethod
+    def _idprop_mapping(cls):
+        return {"target_object": "object_name",
+                "target_material": "material_name",
+                "target_texture": "texture_name"}
+
+    def _idprop_sources(self):
+        return {"object_name": bpy.data.objects,
+                "material_name": bpy.data.materials,
+                "texture_name": bpy.data.textures}
 
 
 class PlasmaEnableMsgNode(PlasmaMessageNode, bpy.types.Node):
@@ -377,14 +407,15 @@ class PlasmaLinkToAgeMsg(PlasmaMessageNode, bpy.types.Node):
         layout.prop(self, "spawn_point")
 
 
-class PlasmaOneShotMsgNode(PlasmaMessageNode, bpy.types.Node):
+class PlasmaOneShotMsgNode(idprops.IDPropObjectMixin, PlasmaMessageNode, bpy.types.Node):
     bl_category = "MSG"
     bl_idname = "PlasmaOneShotMsgNode"
     bl_label = "One Shot"
     bl_width_default = 210
 
-    pos = StringProperty(name="Position",
-                         description="Object defining the OneShot position")
+    pos_object = PointerProperty(name="Position",
+                                 description="Object defining the OneShot position",
+                                 type=bpy.types.Object)
     seek = EnumProperty(name="Seek",
                         description="How the avatar should approach the OneShot position",
                         items=[("SMART", "Smart Seek", "Let the engine figure out the best path"),
@@ -417,7 +448,7 @@ class PlasmaOneShotMsgNode(PlasmaMessageNode, bpy.types.Node):
         row = layout.row()
         row.prop(self, "drivable")
         row.prop(self, "reversable")
-        layout.prop_search(self, "pos", bpy.data, "objects", icon="EMPTY_DATA")
+        layout.prop(self, "pos_object", icon="EMPTY_DATA")
         layout.prop(self, "seek")
 
     def export(self, exporter, bo, so):
@@ -431,21 +462,23 @@ class PlasmaOneShotMsgNode(PlasmaMessageNode, bpy.types.Node):
 
     def get_key(self, exporter, so):
         name = self.key_name
-        if self.pos:
-            bo = bpy.data.objects.get(self.pos, None)
-            if bo is None:
-                raise ExportError("Node '{}' in '{}' specifies an invalid Position Empty".format(self.name, self.id_data.name))
-            pos_so = exporter.mgr.find_create_object(plSceneObject, bl=bo)
+        if self.pos_object is not None:
+            pos_so = exporter.mgr.find_create_object(plSceneObject, bl=self.pos_object)
             return exporter.mgr.find_create_key(plOneShotMod, name=name, so=pos_so)
         else:
             return exporter.mgr.find_create_key(plOneShotMod, name=name, so=so)
 
     def harvest_actors(self):
-        return (self.pos,)
+        if self.pos_object:
+            return (self.pos_object.name,)
 
     @property
     def has_callbacks(self):
         return bool(self.marker)
+
+    @classmethod
+    def _idprop_mapping(cls):
+        return {"pos_object": "pos"}
 
 
 class PlasmaOneShotCallbackSocket(PlasmaMessageSocketBase, bpy.types.NodeSocket):
@@ -456,7 +489,7 @@ class PlasmaOneShotCallbackSocket(PlasmaMessageSocketBase, bpy.types.NodeSocket)
         layout.prop(self, "marker")
 
 
-class PlasmaSceneObjectMsgRcvrNode(PlasmaNodeBase, bpy.types.Node):
+class PlasmaSceneObjectMsgRcvrNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.Node):
     bl_category = "MSG"
     bl_idname = "PlasmaSceneObjectMsgRcvrNode"
     bl_label = "Send To Object"
@@ -471,18 +504,23 @@ class PlasmaSceneObjectMsgRcvrNode(PlasmaNodeBase, bpy.types.Node):
         }),
     ])
 
-    object_name = StringProperty(name="Object",
-                                 description="Object to send the message to")
+    target_object = PointerProperty(name="Object",
+                                    description="Object to send the message to",
+                                    type=bpy.types.Object)
 
     def draw_buttons(self, context, layout):
-        layout.prop_search(self, "object_name", bpy.data, "objects")
+        layout.prop(self, "target_object")
 
     def get_key(self, exporter, so):
-        bo = bpy.data.objects.get(self.object_name, None)
+        bo = self.target_object
         if bo is None:
-            self.raise_error("invalid object specified: '{}'".format(self.object_name))
+            self.raise_error("target object must be specified")
         ref_so_key = exporter.mgr.find_create_key(plSceneObject, bl=bo)
         return ref_so_key
+
+    @classmethod
+    def _idprop_mapping(cls):
+        return {"target_object": "object_name"}
 
 
 class PlasmaSoundMsgNode(idprops.IDPropObjectMixin, PlasmaMessageNode, bpy.types.Node):

--- a/korman/operators/op_lightmap.py
+++ b/korman/operators/op_lightmap.py
@@ -32,8 +32,6 @@ class LightmapAutobakePreviewOperator(_LightingOperator, bpy.types.Operator):
     bl_label = "Preview Lightmap"
     bl_options = {"INTERNAL"}
 
-    light_group = StringProperty(name="Light Group")
-
     def __init__(self):
         super().__init__()
 

--- a/korman/operators/op_sound.py
+++ b/korman/operators/op_sound.py
@@ -36,19 +36,16 @@ class PlasmaSoundOpenOperator(SoundOperator, bpy.types.Operator):
     def execute(self, context):
         # Check to see if the sound exists... Because the sneakily introduced bpy.data.sounds.load
         # check_existing doesn't tell us if it already exists... dammit...
-        # We don't want to take ownership forcefully if we don't have to.
         for i in bpy.data.sounds:
             if self.filepath == i.filepath:
                 sound = i
                 break
         else:
             sound = bpy.data.sounds.load(self.filepath)
-            sound.plasma_owned = True
-            sound.use_fake_user = True
 
         # Now do the stanky leg^H^H^H^H^H^H^H^H^H^H deed and put the sound on the mod
         dest = eval(self.data_path)
-        setattr(dest, self.sound_property, sound.name)
+        setattr(dest, self.sound_property, sound)
         return {"FINISHED"}
 
     def invoke(self, context, event):

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -19,29 +19,31 @@ from PyHSPlasma import *
 
 from .base import PlasmaModifierProperties
 from ...exporter import ExportError
+from ... import idprops
 
 game_versions = [("pvPrime", "Ages Beyond Myst (63.11)", "Targets the original Uru (Live) game"),
                  ("pvPots", "Path of the Shell (63.12)", "Targets the most recent offline expansion pack"),
                  ("pvMoul", "Myst Online: Uru Live (70)", "Targets the most recent online game")]
 
-class PlasmaVersionedNodeTree(bpy.types.PropertyGroup):
+class PlasmaVersionedNodeTree(idprops.IDPropMixin, bpy.types.PropertyGroup):
     name = StringProperty(name="Name")
     version = EnumProperty(name="Version",
                            description="Plasma versions this node tree exports under",
                            items=game_versions,
                            options={"ENUM_FLAG"},
                            default=set(list(zip(*game_versions))[0]))
-    node_tree_name = StringProperty(name="Node Tree",
-                                    description="Node Tree to export")
+    node_tree = PointerProperty(name="Node Tree",
+                                description="Node Tree to export",
+                                type=bpy.types.NodeTree)
     node_name = StringProperty(name="Node Ref",
                                description="Attach a reference to this node")
 
-    @property
-    def node_tree(self):
-        try:
-            return bpy.data.node_groups[self.node_tree_name]
-        except KeyError:
-            raise ExportError("Node Tree '{}' does not exist!".format(self.node_tree_name))
+    @classmethod
+    def _idprop_mapping(cls):
+        return {"node_tree": "node_tree_name"}
+
+    def _idprop_sources(self):
+        return {"node_tree_name": bpy.data.node_groups}
 
 
 class PlasmaAdvancedLogic(PlasmaModifierProperties):
@@ -60,19 +62,22 @@ class PlasmaAdvancedLogic(PlasmaModifierProperties):
         for i in self.logic_groups:
             our_versions = [globals()[j] for j in i.version]
             if version in our_versions:
+                if i.node_tree is None:
+                    raise ExportError("'{}': Advanced Logic is missing a node tree for '{}'".format(bo.name, i.version))
+
                 # If node_name is defined, then we're only adding a reference. We will make sure that
                 # the entire node tree is exported once before the post_export step, however.
                 if i.node_name:
-                    exporter.want_node_trees[i.node_tree_name] = (bo, so)
+                    exporter.want_node_trees[i.node_tree.name] = (bo, so)
                     node = i.node_tree.nodes.get(i.node_name, None)
                     if node is None:
-                        raise ExportError("Node '{}' does not exist in '{}'".format(i.node_name, i.node_tree_name))
+                        raise ExportError("Node '{}' does not exist in '{}'".format(i.node_name, i.node_tree.name))
                     # We are going to assume get_key will do the adding correctly. Single modifiers
                     # should fetch the appropriate SceneObject before doing anything, so this will
                     # be a no-op in that case. Multi modifiers should accept any SceneObject, however
                     node.get_key(exporter, so)
                 else:
-                    exporter.node_trees_exported.add(i.node_tree_name)
+                    exporter.node_trees_exported.add(i.node_tree.name)
                     i.node_tree.export(exporter, bo, so)
 
     def harvest_actors(self):

--- a/korman/properties/modifiers/region.py
+++ b/korman/properties/modifiers/region.py
@@ -88,7 +88,7 @@ class PlasmaFootstepRegion(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         # Region Sensor
         volsens = nodes.new("PlasmaVolumeSensorNode")
         volsens.name = "RegionSensor"
-        volsens.region = bo.name
+        volsens.region_object = bo
         volsens.bounds = self.bounds
         volsens.find_input_socket("enter").allow = True
         volsens.find_input_socket("exit").allow = True

--- a/korman/properties/prop_lamp.py
+++ b/korman/properties/prop_lamp.py
@@ -16,7 +16,9 @@
 import bpy
 from bpy.props import *
 
-class PlasmaLamp(bpy.types.PropertyGroup):
+from .. import idprops
+
+class PlasmaLamp(idprops.IDPropObjectMixin, bpy.types.PropertyGroup):
     affect_characters = BoolProperty(name="Affect Avatars",
                                      description="This lamp affects avatars",
                                      options=set(),
@@ -43,9 +45,10 @@ class PlasmaLamp(bpy.types.PropertyGroup):
                                default=False,
                                options=set())
 
-    soft_region = StringProperty(name="Soft Volume",
-                                 description="Soft region this light is active inside",
-                                 options=set())
+    lamp_region = PointerProperty(name="Soft Volume",
+                                  description="Soft region this light is active inside",
+                                  type=bpy.types.Object,
+                                  poll=idprops.poll_softvolume_objects)
 
     # For LimitedDirLights
     size_height = FloatProperty(name="Height",
@@ -55,3 +58,7 @@ class PlasmaLamp(bpy.types.PropertyGroup):
 
     def has_light_group(self, bo):
         return bool(bo.users_group)
+
+    @classmethod
+    def _idprop_mapping(cls):
+        return {"lamp_region": "soft_region"}

--- a/korman/properties/prop_texture.py
+++ b/korman/properties/prop_texture.py
@@ -16,10 +16,18 @@
 import bpy
 from bpy.props import *
 
-class EnvMapVisRegion(bpy.types.PropertyGroup):
+from .. import idprops
+
+class EnvMapVisRegion(idprops.IDPropObjectMixin, bpy.types.PropertyGroup):
     enabled = BoolProperty(default=True)
-    region_name = StringProperty(name="Control",
-                                 description="Object defining a Plasma Visibility Control")
+    control_region = PointerProperty(name="Control",
+                                     description="Object defining a Plasma Visibility Control",
+                                     type=bpy.types.Object,
+                                     poll=idprops.poll_visregion_objects)
+
+    @classmethod
+    def _idprop_mapping(cls):
+        return {"control_region": "region_name"}
 
 
 class PlasmaLayer(bpy.types.PropertyGroup):

--- a/korman/ui/modifiers/anim.py
+++ b/korman/ui/modifiers/anim.py
@@ -45,8 +45,8 @@ def animation(modifier, layout, context):
 
 class GroupListUI(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_property, index=0, flt_flag=0):
-        label = item.object_name if item.object_name else "[No Child Specified]"
-        icon = "ACTION" if item.object_name else "ERROR"
+        label = item.child_anim.name if item.child_anim is not None else "[No Child Specified]"
+        icon = "ACTION" if item.child_anim is not None else "ERROR"
         layout.label(text=label, icon=icon)
 
 
@@ -68,7 +68,7 @@ def animation_group(modifier, layout, context):
     op.index = modifier.active_child_index
 
     if modifier.children:
-        layout.prop_search(modifier.children[modifier.active_child_index], "object_name", bpy.data, "objects", icon="ACTION")
+        layout.prop(modifier.children[modifier.active_child_index], "child_anim", icon="ACTION")
 
 
 class LoopListUI(bpy.types.UIList):

--- a/korman/ui/modifiers/avatar.py
+++ b/korman/ui/modifiers/avatar.py
@@ -21,14 +21,14 @@ def sittingmod(modifier, layout, context):
     layout.row().prop(modifier, "approach")
 
     col = layout.column()
-    col.prop_search(modifier, "clickable_obj", bpy.data, "objects", icon="MESH_DATA")
-    clickable = find_modifier(modifier.clickable_obj, "collision")
+    col.prop(modifier, "clickable_object", icon="MESH_DATA")
+    clickable = find_modifier(modifier.clickable_object, "collision")
     if clickable is not None:
         col.prop(clickable, "bounds")
 
     col = layout.column()
-    col.prop_search(modifier, "region_obj", bpy.data, "objects", icon="MESH_DATA")
-    region = find_modifier(modifier.region_obj, "collision")
+    col.prop(modifier, "region_object", icon="MESH_DATA")
+    region = find_modifier(modifier.region_object, "collision")
     if region is not None:
         col.prop(region, "bounds")
 

--- a/korman/ui/modifiers/logic.py
+++ b/korman/ui/modifiers/logic.py
@@ -39,7 +39,7 @@ def advanced_logic(modifier, layout, context):
     if modifier.logic_groups:
         logic = modifier.logic_groups[modifier.active_group_index]
         layout.row().prop_menu_enum(logic, "version")
-        layout.prop_search(logic, "node_tree_name", bpy.data, "node_groups", icon="NODETREE")
+        layout.prop(logic, "node_tree", icon="NODETREE")
         try:
             layout.prop_search(logic, "node_name", logic.node_tree, "nodes", icon="NODE")
         except:

--- a/korman/ui/modifiers/region.py
+++ b/korman/ui/modifiers/region.py
@@ -28,7 +28,7 @@ def softvolume(modifier, layout, context):
     row = layout.row()
     row.prop(modifier, "use_nodes", text="", icon="NODETREE")
     if modifier.use_nodes:
-        row.prop_search(modifier, "node_tree_name", bpy.data, "node_groups")
+        row.prop(modifier, "node_tree")
     else:
         row.label("Simple Soft Volume")
 

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -43,7 +43,7 @@ def followmod(modifier, layout, context):
     layout.row().prop(modifier, "follow_mode", expand=True)
     layout.prop(modifier, "leader_type")
     if modifier.leader_type == "kFollowObject":
-        layout.prop_search(modifier, "leader_object", bpy.data, "objects", icon="OUTLINER_OB_MESH")
+        layout.prop(modifier, "leader", icon="OUTLINER_OB_MESH")
 
 def lighting(modifier, layout, context):
     split = layout.split()
@@ -84,11 +84,10 @@ def lighting(modifier, layout, context):
 def lightmap(modifier, layout, context):
     layout.row(align=True).prop(modifier, "quality", expand=True)
     layout.prop(modifier, "render_layers", text="Active Render Layers")
-    layout.prop_search(modifier, "light_group", bpy.data, "groups", icon="GROUP")
+    layout.prop(modifier, "lights")
     layout.prop_search(modifier, "uv_map", context.active_object.data, "uv_textures")
 
     operator = layout.operator("object.plasma_lightmap_preview", "Preview Lightmap", icon="RENDER_STILL")
-    operator.light_group = modifier.light_group
 
     # Kind of clever stuff to show the user a preview...
     # We can't show images, so we make a hidden ImageTexture called LIGHTMAPGEN_PREVIEW. We check
@@ -117,7 +116,7 @@ def viewfacemod(modifier, layout, context):
     if modifier.preset_options == "Custom":
         layout.row().prop(modifier, "follow_mode")
         if modifier.follow_mode == "kFaceObj":
-            layout.prop_search(modifier, "target_object", bpy.data, "objects", icon="OUTLINER_OB_MESH")
+            layout.prop(modifier, "target", icon="OUTLINER_OB_MESH")
             layout.separator()
 
         layout.prop(modifier, "pivot_on_y")
@@ -136,9 +135,10 @@ def viewfacemod(modifier, layout, context):
 
 class VisRegionListUI(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_property, index=0, flt_flag=0):
-        myIcon = "ERROR" if bpy.data.objects.get(item.region_name, None) is None else "OBJECT_DATA"
-        label = item.region_name if item.region_name else "[No Object Specified]"
-        layout.label(label, icon=myIcon)
+        if item.control_region is None:
+            layout.label("[No Object Specified]", icon="ERROR")
+        else:
+            layout.label(item.control_region.name, icon="OBJECT_DATA")
         layout.prop(item, "enabled", text="")
 
 
@@ -156,7 +156,7 @@ def visibility(modifier, layout, context):
     op.index = modifier.active_region_index
 
     if modifier.regions:
-        layout.prop_search(modifier.regions[modifier.active_region_index], "region_name", bpy.data, "objects")
+        layout.prop(modifier.regions[modifier.active_region_index], "control_region")
 
 def visregion(modifier, layout, context):
     layout.prop(modifier, "mode")
@@ -164,7 +164,7 @@ def visregion(modifier, layout, context):
     # Only allow SoftVolume spec if this is not an FX and this object is not an SV itself
     sv = modifier.id_data.plasma_modifiers.softvolume
     if modifier.mode != "fx" and not sv.enabled:
-        layout.prop_search(modifier, "softvolume", bpy.data, "objects")
+        layout.prop(modifier, "soft_region")
 
     # Other settings
     layout.prop(modifier, "replace_normal")

--- a/korman/ui/modifiers/sound.py
+++ b/korman/ui/modifiers/sound.py
@@ -22,10 +22,8 @@ def _draw_fade_ui(modifier, layout, label):
 
 class SoundListUI(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_property, index=0, flt_flag=0):
-        if item.sound_data:
-            sound = bpy.data.sounds.get(item.sound_data)
-            icon = "SOUND" if sound is not None else "ERROR"
-            layout.prop(item, "name", emboss=False, icon=icon, text="")
+        if item.sound:
+            layout.prop(item, "name", emboss=False, icon="SOUND", text="")
             layout.prop(item, "enabled", text="")
         else:
             layout.label("[Empty]")
@@ -51,13 +49,13 @@ def soundemit(modifier, layout, context):
     else:
         # Sound datablock picker
         row = layout.row(align=True)
-        row.prop_search(sound, "sound_data", bpy.data, "sounds", text="")
+        row.prop_search(sound, "sound_data_proxy", bpy.data, "sounds", text="")
         open_op = row.operator("sound.plasma_open", icon="FILESEL", text="")
         open_op.data_path = repr(sound)
         open_op.sound_property = "sound_data"
 
         # Pack/Unpack
-        data = bpy.data.sounds.get(sound.sound_data)
+        data = sound.sound
         if data is not None:
             if data.packed_file is None:
                 row.operator("sound.plasma_pack", icon="UGLYPACKAGE", text="")
@@ -65,7 +63,7 @@ def soundemit(modifier, layout, context):
                 row.operator_menu_enum("sound.plasma_unpack", "method", icon="PACKAGE", text="")
 
         # If an invalid sound data block is spec'd, let them know about it.
-        if sound.sound_data and not sound.is_valid:
+        if data and not sound.is_valid:
             layout.label(text="Invalid sound specified", icon="ERROR")
 
         # Core Props
@@ -102,4 +100,4 @@ def soundemit(modifier, layout, context):
         if not sv.enabled:
             col.separator()
             col.label("Soft Region:")
-            col.prop_search(sound, "soft_region", bpy.data, "objects", text="")
+            col.prop(sound, "sfx_region", text="")

--- a/korman/ui/modifiers/water.py
+++ b/korman/ui/modifiers/water.py
@@ -19,9 +19,9 @@ def swimregion(modifier, layout, context):
     split = layout.split()
     col = split.column()
     col.label("Detector Region:")
-    col.prop_search(modifier, "region_name", bpy.data, "objects", text="")
+    col.prop(modifier, "region", text="")
 
-    region_bo = bpy.data.objects.get(modifier.region_name, None)
+    region_bo = modifier.region
     col = split.column()
     col.enabled = region_bo is not None
     bounds_src = region_bo if region_bo is not None else modifier.id_data
@@ -52,11 +52,11 @@ def swimregion(modifier, layout, context):
         col.prop(modifier, "near_velocity", text="Near")
         col.prop(modifier, "far_velocity", text="Far")
 
-        layout.prop_search(modifier, "current_object", bpy.data, "objects")
+        layout.prop(modifier, "current")
 
 def water_basic(modifier, layout, context):
-    layout.prop_search(modifier, "wind_object_name", bpy.data, "objects")
-    layout.prop_search(modifier, "envmap_name", bpy.data, "textures")
+    layout.prop(modifier, "wind_object")
+    layout.prop(modifier, "envmap")
 
     row = layout.row()
     row.prop(modifier, "wind_speed")
@@ -128,7 +128,7 @@ def water_shore(modifier, layout, context):
     # Display the active shore
     if modifier.shores:
         shore = modifier.shores[modifier.active_shore_index]
-        layout.prop_search(shore, "object_name", bpy.data, "objects", icon="MESH_DATA")
+        layout.prop(shore, "shore_object", icon="MESH_DATA")
 
     split = layout.split()
     col = split.column()

--- a/korman/ui/ui_lamp.py
+++ b/korman/ui/ui_lamp.py
@@ -53,7 +53,7 @@ class PlasmaLampPanel(LampButtonsPanel, bpy.types.Panel):
 
         if not context.object.plasma_modifiers.softvolume.enabled:
             layout.separator()
-            layout.prop_search(rtlamp, "soft_region", bpy.data, "objects")
+            layout.prop(rtlamp, "lamp_region")
 
 
 def _draw_area_lamp(self, context):

--- a/korman/ui/ui_texture.py
+++ b/korman/ui/ui_texture.py
@@ -52,7 +52,7 @@ class PlasmaEnvMapPanel(TextureButtonsPanel, bpy.types.Panel):
         op.index = layer_props.active_region_index
         rgns = layer_props.vis_regions
         if layer_props.vis_regions:
-            layout.prop_search(rgns[layer_props.active_region_index], "region_name", bpy.data, "objects")
+            layout.prop(rgns[layer_props.active_region_index], "control_region")
 
         layout.separator()
         layout.prop(layer_props, "envmap_color")


### PR DESCRIPTION
:boom: :boom: :boom:

This changeset converts all string object reference properties in Korman to Blender 2.79's new ID Datablock Properties. This will help reduce the amount of boilerplate needed in the exporter around object references as Blender will now take care of sanitizing the data for us. The only downside to this is that the minimum version of Blender is now bumped to 2.79. Additionally, any blendfiles saved with this enabled [will crash older versions of Blender](https://wiki.blender.org/index.php/Dev:Ref/Release_Notes/2.79/Datablocks#Custom_Properties).

Core
- [x] Lamps
- [x] Objects
- [x] Textures
- [x] Worlds

Modifiers
- [x] Animation
- [x] Avatar
- [x] Logic
- [x] Physics
- [x] Region
- [x] Render
- [x] Sound
- [x] Water

Nodes
- [x] Avatar
- [x] Conditions
- [x] Logic
- [x] Message
- [x] Python
- [x] Responder
- [x] Soft Volume