### PR TITLE
Improved export progress logging

### DIFF
--- a/korman/__init__.py
+++ b/korman/__init__.py
@@ -22,7 +22,7 @@ from . import operators
 bl_info = {
     "name":        "Korman",
     "author":      "Guild of Writers",
-    "blender":     (2, 77, 0),
+    "blender":     (2, 78, 0),
     "location":    "File > Import-Export",
     "description": "Exporter for Cyan Worlds' Plasma Engine",
     "warning":     "beta",

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -42,7 +42,8 @@ class Exporter:
         return Path(self._op.filepath).stem
 
     def run(self):
-        with logger.ExportProgressLogger(self._op.filepath) as self.report:
+        log = logger.ExportVerboseLogger if self._op.verbose else logger.ExportProgressLogger
+        with log(self._op.filepath) as self.report:
             # Step 0: Init export resmgr and stuff
             self.mgr = manager.ExportManager(self)
             self.mesh = mesh.MeshConverter(self)

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -42,7 +42,7 @@ class Exporter:
         return Path(self._op.filepath).stem
 
     def run(self):
-        with logger.ExportLogger(self._op.filepath) as self.report:
+        with logger.ExportProgressLogger(self._op.filepath) as self.report:
             # Step 0: Init export resmgr and stuff
             self.mgr = manager.ExportManager(self)
             self.mesh = mesh.MeshConverter(self)

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -14,6 +14,7 @@
 #    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
+from ..korlib import ConsoleToggler
 from pathlib import Path
 from PyHSPlasma import *
 import time
@@ -43,7 +44,7 @@ class Exporter:
 
     def run(self):
         log = logger.ExportVerboseLogger if self._op.verbose else logger.ExportProgressLogger
-        with log(self._op.filepath) as self.report:
+        with ConsoleToggler(self._op.show_console), log(self._op.filepath) as self.report:
             # Step 0: Init export resmgr and stuff
             self.mgr = manager.ExportManager(self)
             self.mesh = mesh.MeshConverter(self)

--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -16,7 +16,7 @@
 import bpy
 from bpy.app.handlers import persistent
 
-from .logger import ExportLogger
+from .logger import ExportProgressLogger
 from .mesh import _VERTEX_COLOR_LAYERS
 from ..helpers import *
 
@@ -28,7 +28,7 @@ class LightBaker:
     def __init__(self, report=None):
         self._lightgroups = {}
         if report is None:
-            self._report = ExportLogger()
+            self._report = ExportProgressLogger()
             self.add_progress_steps(self._report)
             self._report.progress_start("PREVIEWING LIGHTING")
             self._own_report = True

--- a/korman/exporter/logger.py
+++ b/korman/exporter/logger.py
@@ -13,6 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
 
+from ..korlib import ConsoleToggler
 from pathlib import Path
 import threading
 import time
@@ -40,6 +41,8 @@ class _ExportLogger:
         return self
 
     def __exit__(self, type, value, traceback):
+        if value is not None:
+            ConsoleToggler().keep_console = True
         self._file.close()
         return False
 

--- a/korman/exporter/logger.py
+++ b/korman/exporter/logger.py
@@ -15,21 +15,30 @@
 
 from pathlib import Path
 import sys
+import time
+
+_HEADING_SIZE = 50
 
 class ExportLogger:
     def __init__(self, age_path=None):
         self._porting = []
         self._warnings = []
-        self._age_path = age_path
+        self._age_path = Path(age_path) if age_path is not None else None
         self._file = None
+
+        self._progress_steps = []
+        self._step_id = -1
+        self._step_max = 0
+        self._step_progress = 0
+        self._time_start_overall = 0
+        self._time_start_step = 0
 
     def __enter__(self):
         assert self._age_path is not None
 
         # Make the log file name from the age file path -- this ensures we're not trying to write
         # the log file to the same directory Blender.exe is in, which might be a permission error
-        my_path = Path(self._age_path)
-        my_path = my_path.with_name("{}_export".format(my_path.stem)).with_suffix(".log")
+        my_path = self._age_path.with_name("{}_export".format(self._age_path.stem)).with_suffix(".log")
         self._file = open(str(my_path), "w")
         return self
 
@@ -37,15 +46,101 @@ class ExportLogger:
         self._file.close()
         return False
 
+    def progress_add_step(self, name):
+        assert self._step_id == -1
+        self._progress_steps.append(name)
+
+    def progress_advance(self):
+        """Advances the progress bar to the next step"""
+        if self._step_id != -1:
+            self._progress_print_step(done=True)
+        assert self._step_id < len(self._progress_steps)
+
+        self._step_id += 1
+        self._step_max = 0
+        self._step_progress = 0
+        self._time_start_step = time.perf_counter()
+        self._progress_print_step()
+
+    def progress_complete_step(self):
+        """Manually completes the current step"""
+        assert self._step_id != -1
+        self._progress_print_step(done=True)
+
+    def progress_end(self):
+        self._progress_print_step(done=True)
+        assert self._step_id+1 == len(self._progress_steps)
+
+        export_time = time.perf_counter() - self._time_start_overall
+        if self._age_path is not None:
+            self.msg("\nExported '{}' in {:.2f}s", self._age_path.name, export_time)
+            print("\nEXPORTED '{}' IN {:.2f}s".format(self._age_path.name, export_time))
+        else:
+            print("\nCOMPLETED IN {:.2f}s".format(export_time))
+        self._progress_print_heading()
+        print()
+
+    def progress_increment(self):
+        """Increments the progress of the current step"""
+        assert self._step_id != -1
+        self._step_progress += 1
+        if self._step_max != 0:
+            self._progress_print_step()
+
+    def _progress_print_heading(self, text=None):
+        if text:
+            num_chars = len(text)
+            border = "-" * int((_HEADING_SIZE - (num_chars + 2)) / 2)
+            pad = " " if num_chars % 2 == 1 else ""
+            print(border, " ", pad, text, " ", border, sep="")
+        else:
+            print("-" * _HEADING_SIZE)
+
+    def _progress_print_step(self, done=False):
+        if done:
+            stage = "DONE IN {:.2f}s".format(time.perf_counter() - self._time_start_step)
+            end = "\n"
+        else:
+            if self._step_max != 0:
+                stage = "{} of {}".format(self._step_progress, self._step_max)
+            else:
+                stage = ""
+            end = "\r"
+        print("{}\t(step {}/{}): {}".format(self._progress_steps[self._step_id], self._step_id+1,
+                                            len(self._progress_steps), stage),
+              end=end)
+
+    def _progress_get_max(self):
+        return self._step_max
+    def _progress_set_max(self, value):
+        assert self._step_id != -1
+        self._step_max = value
+        self._progress_print_step()
+    progress_range = property(_progress_get_max, _progress_set_max)
+
+    def progress_start(self, action):
+        if self._age_path is not None:
+            self.msg("Exporting '{}'", self._age_path.name)
+        self._progress_print_heading("Korman")
+        self._progress_print_heading(action)
+        self._time_start_overall = time.perf_counter()
+
+    def _progress_get_current(self):
+        return self._step_progress
+    def _progress_set_current(self, value):
+        assert self._step_id != -1
+        self._step_progress = value
+        if self._step_max != 0:
+            self._progress_print_step()
+    progress_value = property(_progress_get_current, _progress_set_current)
+
     def msg(self, *args, **kwargs):
         assert args
-        indent = kwargs.get("indent", 0)
-        msg = "{}{}".format("    " * indent, args[0])
-        if len(args) > 1:
-            msg = msg.format(*args[1:], **kwargs)
-        if self._file is None:
-            print(msg)
-        else:
+        if self._file is not None:
+            indent = kwargs.get("indent", 0)
+            msg = "{}{}".format("    " * indent, args[0])
+            if len(args) > 1:
+                msg = msg.format(*args[1:], **kwargs)
             self._file.writelines((msg, "\n"))
 
     def port(self, *args, **kwargs):
@@ -54,9 +149,7 @@ class ExportLogger:
         msg = "{}PORTING: {}".format("    " * indent, args[0])
         if len(args) > 1:
             msg = msg.format(*args[1:], **kwargs)
-        if self._file is None:
-            print(msg)
-        else:
+        if self._file is not None:
             self._file.writelines((msg, "\n"))
         self._porting.append(args[0])
 
@@ -70,8 +163,6 @@ class ExportLogger:
         msg = "{}WARNING: {}".format("    " * indent, args[0])
         if len(args) > 1:
             msg = msg.format(*args[1:], **kwargs)
-        if self._file is None:
-            print(msg)
-        else:
+        if self._file is not None:
             self._file.writelines((msg, "\n"))
         self._warnings.append(args[0])

--- a/korman/exporter/logger.py
+++ b/korman/exporter/logger.py
@@ -16,61 +16,62 @@
 from pathlib import Path
 import sys
 
-class ExportAnalysis:
-    """This is used to collect artist action items from the export process. You can warn about
-       portability issues, possible oversights, etc. The benefit here is that the user doesn't have
-       to look through all of the gobbledygook in the export log.
-    """
+class ExportLogger:
+    def __init__(self, age_path=None):
+        self._porting = []
+        self._warnings = []
+        self._age_path = age_path
+        self._file = None
 
-    _porting = []
-    _warnings = []
+    def __enter__(self):
+        assert self._age_path is not None
+
+        # Make the log file name from the age file path -- this ensures we're not trying to write
+        # the log file to the same directory Blender.exe is in, which might be a permission error
+        my_path = Path(self._age_path)
+        my_path = my_path.with_name("{}_export".format(my_path.stem)).with_suffix(".log")
+        self._file = open(str(my_path), "w")
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self._file.close()
+        return False
+
+    def msg(self, *args, **kwargs):
+        assert args
+        indent = kwargs.get("indent", 0)
+        msg = "{}{}".format("    " * indent, args[0])
+        if len(args) > 1:
+            msg = msg.format(*args[1:], **kwargs)
+        if self._file is None:
+            print(msg)
+        else:
+            self._file.writelines((msg, "\n"))
+
+    def port(self, *args, **kwargs):
+        assert args
+        indent = kwargs.get("indent", 0)
+        msg = "{}PORTING: {}".format("    " * indent, args[0])
+        if len(args) > 1:
+            msg = msg.format(*args[1:], **kwargs)
+        if self._file is None:
+            print(msg)
+        else:
+            self._file.writelines((msg, "\n"))
+        self._porting.append(args[0])
 
     def save(self):
         # TODO
         pass
 
-    def port(self, message, indent=0):
-        self._porting.append(message)
-        print("    " * indent, end="")
-        print("PORTING: {}".format(message))
-
-    def warn(self, message, indent=0):
-        self._warnings.append(message)
-        print("    " * indent, end="")
-        print("WARNING: {}".format(message))
-
-
-class ExportLogger:
-    """Yet Another Logger(TM)"""
-
-    def __init__(self, ageFile):
-        # Make the log file name from the age file path -- this ensures we're not trying to write
-        # the log file to the same directory Blender.exe is in, which might be a permission error
-        my_path = Path(ageFile)
-        my_path = my_path.with_name("{}_export".format(my_path.stem)).with_suffix(".log")
-        self._file = open(str(my_path), "w")
-
-        for i in dir(self._file):
-            if not hasattr(self, i):
-                setattr(self, i, getattr(self._file, i))
-
-    def __enter__(self):
-        self._stdout, sys.stdout = sys.stdout, self._file
-        self._stderr, sys.stderr = sys.stderr, self._file
-
-    def __exit__(self, type, value, traceback):
-        sys.stdout = self._stdout
-        sys.stderr = self._stderr
-
-    def flush(self):
-        self._file.flush()
-        self._stdout.flush()
-        self._stderr.flush()
-
-    def write(self, str):
-        self._file.write(str)
-        self._stdout.write(str)
-
-    def writelines(self, seq):
-        self._file.writelines(seq)
-        self._stdout.writelines(seq)
+    def warn(self, *args, **kwargs):
+        assert args
+        indent = kwargs.get("indent", 0)
+        msg = "{}WARNING: {}".format("    " * indent, args[0])
+        if len(args) > 1:
+            msg = msg.format(*args[1:], **kwargs)
+        if self._file is None:
+            print(msg)
+        else:
+            self._file.writelines((msg, "\n"))
+        self._warnings.append(args[0])

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -618,6 +618,10 @@ class MaterialConverter:
             self._pending[key].append(layer.key)
 
     def finalize(self):
+        self._report.progress_advance()
+        self._report.progress_range = len(self._pending)
+        inc_progress = self._report.progress_increment
+
         for key, layers in self._pending.items():
             name = str(key)
             self._report.msg("\n[Mipmap '{}']", name)
@@ -683,6 +687,7 @@ class MaterialConverter:
                 else:
                     mipmap = pages[page]
                 layer.object.texture = mipmap.key
+            inc_progress()
 
     def get_materials(self, bo):
         return self._obj2mat.get(bo, [])

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -174,11 +174,15 @@ class MeshConverter:
 
     def finalize(self):
         """Prepares all baked Plasma geometry to be flushed to the disk"""
+        self._report.progress_advance()
+        self._report.progress_range = len(self._dspans)
+        inc_progress = self._report.progress_increment
+        log_msg = self._report.msg
 
+        log_msg("\nFinalizing Geometry")
         for loc in self._dspans.values():
             for dspan in loc.values():
-                self._report.msg("\n[DrawableSpans '{}']", dspan.key.name)
-                self._report.msg("Composing geometry data", indent=1)
+                log_msg("[DrawableSpans '{}']", dspan.key.name, indent=1)
 
                 # This mega-function does a lot:
                 # 1. Converts SourceSpans (geospans) to Icicles and bakes geometry into plGBuffers
@@ -186,10 +190,7 @@ class MeshConverter:
                 # 3. Builds the plSpaceTree
                 # 4. Clears the SourceSpans
                 dspan.composeGeometry(True, True)
-
-                # Might as well say something else just to fascinate anyone who is playing along
-                # at home (and actually enjoys reading these lawgs)
-                self._report.msg("Bounds and SpaceTree in the saddle", indent=1)
+                inc_progress()
 
     def _export_geometry(self, bo, mesh, materials, geospans):
         geodata = [_GeoData(len(mesh.vertices)) for i in materials]

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -177,8 +177,8 @@ class MeshConverter:
 
         for loc in self._dspans.values():
             for dspan in loc.values():
-                print("\n[DrawableSpans '{}']".format(dspan.key.name))
-                print("    Composing geometry data")
+                self._report.msg("\n[DrawableSpans '{}']", dspan.key.name)
+                self._report.msg("Composing geometry data", indent=1)
 
                 # This mega-function does a lot:
                 # 1. Converts SourceSpans (geospans) to Icicles and bakes geometry into plGBuffers
@@ -189,7 +189,7 @@ class MeshConverter:
 
                 # Might as well say something else just to fascinate anyone who is playing along
                 # at home (and actually enjoys reading these lawgs)
-                print("    Bounds and SpaceTree in the saddle")
+                self._report.msg("Bounds and SpaceTree in the saddle", indent=1)
 
     def _export_geometry(self, bo, mesh, materials, geospans):
         geodata = [_GeoData(len(mesh.vertices)) for i in materials]
@@ -422,7 +422,8 @@ class MeshConverter:
             _diindices = {}
             for geospan, pass_index in geospans:
                 dspan = self._find_create_dspan(bo, geospan.material.object, pass_index)
-                print("    Exported hsGMaterial '{}' geometry into '{}'".format(geospan.material.name, dspan.key.name))
+                self._report.msg("Exported hsGMaterial '{}' geometry into '{}'",
+                                 geospan.material.name, dspan.key.name, indent=1)
                 idx = dspan.addSourceSpan(geospan)
                 if dspan not in _diindices:
                     _diindices[dspan] = [idx,]
@@ -497,3 +498,7 @@ class MeshConverter:
     @property
     def _mgr(self):
         return self._exporter().mgr
+
+    @property
+    def _report(self):
+        return self._exporter().report

--- a/korman/korlib/__init__.py
+++ b/korman/korlib/__init__.py
@@ -71,4 +71,5 @@ except ImportError:
         size = stream.readInt()
         return (header, size)
 else:
+    from .console import ConsoleToggler
     from .texture import TEX_DETAIL_ALPHA, TEX_DETAIL_ADD, TEX_DETAIL_MULTIPLY

--- a/korman/korlib/console.py
+++ b/korman/korlib/console.py
@@ -1,0 +1,83 @@
+#    This file is part of Korman.
+#
+#    Korman is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Korman is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
+
+import bpy
+import ctypes
+import math
+import sys
+
+class ConsoleToggler:
+    _instance = None
+
+    def __init__(self, want_console=None):
+        if want_console is not None:
+            self._console_wanted = want_console
+
+    def __new__(cls, want_console=None):
+        if cls._instance is None:
+            assert want_console is not None
+            cls._instance = object.__new__(cls)
+            cls._instance._console_was_visible = cls.is_console_visible()
+            cls._instance._console_wanted = want_console
+            cls._instance._context_active = False
+            cls._instance.keep_console = False
+        return cls._instance
+
+    def __enter__(self):
+        if self._context_active:
+            raise RuntimeError("ConsoleToggler context manager is not reentrant")
+        self._console_visible = self.is_console_visible()
+        self._context_active = True
+        self.activate_console()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if not self._console_was_visible and self._console_wanted:
+            if self.keep_console:
+                # Blender thinks the console is currently not visible. However, it actually is.
+                # So, we will fire off the toggle operator to keep Blender's internal state valid
+                bpy.ops.wm.console_toggle()
+            else:
+                self.hide_console()
+        self._context_active = False
+        self.keep_console = False
+        return False
+
+    def activate_console(self):
+        if sys.platform == "win32":
+            hwnd = ctypes.windll.kernel32.GetConsoleWindow()
+            if self._console_wanted:
+                ctypes.windll.user32.ShowWindow(hwnd, 1)
+            if self._console_was_visible or self._console_wanted:
+                ctypes.windll.user32.BringWindowToTop(hwnd)
+
+    @staticmethod
+    def hide_console():
+        if sys.platform == "win32":
+            hwnd = ctypes.windll.kernel32.GetConsoleWindow()
+            ctypes.windll.user32.ShowWindow(hwnd, 0)
+
+    @staticmethod
+    def is_console_visible():
+        if sys.platform == "win32":
+            hwnd = ctypes.windll.kernel32.GetConsoleWindow()
+            return bool(ctypes.windll.user32.IsWindowVisible(hwnd))
+
+    @staticmethod
+    def is_platform_supported():
+        # If you read Blender's source code, GHOST_toggleConsole (the "Toggle System Console" menu
+        # item) is only implemented on Windows. The majority of our audience is on Windows as well,
+        # so I honestly don't see this as an issue...
+        return sys.platform == "win32"

--- a/korman/korlib/texture.py
+++ b/korman/korlib/texture.py
@@ -76,14 +76,14 @@ class GLTexture:
         # It will simplify our state tracking a bit.
         bgl.glTexParameteri(bgl.GL_TEXTURE_2D, bgl.GL_GENERATE_MIPMAP, 1)
 
-    def get_level_data(self, level=0, calc_alpha=False, bgra=False, quiet=False, fast=False):
+    def get_level_data(self, level=0, calc_alpha=False, bgra=False, report=None, fast=False):
         """Gets the uncompressed pixel data for a requested mip level, optionally calculating the alpha
            channel from the image color data
         """
         width = self._get_tex_param(bgl.GL_TEXTURE_WIDTH, level)
         height = self._get_tex_param(bgl.GL_TEXTURE_HEIGHT, level)
-        if not quiet:
-            print("        Level #{}: {}x{}".format(level, width, height))
+        if report is not None:
+            report.msg("Level #{}: {}x{}", level, width, height, indent=2)
 
         # Grab the image data
         size = width * height * 4
@@ -138,7 +138,7 @@ class GLTexture:
 
     @property
     def has_alpha(self):
-        data = self.get_level_data(quiet=True, fast=True)
+        data = self.get_level_data(report=None, fast=True)
         for i in range(3, len(data), 4):
             if data[i] != 255:
                 return True

--- a/korman/nodes/node_conditions.py
+++ b/korman/nodes/node_conditions.py
@@ -427,18 +427,18 @@ class PlasmaVolumeSensorNode(PlasmaNodeBase, bpy.types.Node):
             suffix = "Exit"
 
         theName = "{}_{}_{}".format(self.id_data.name, self.name, suffix)
-        print("        [LogicModifier '{}']".format(theName))
+        exporter.report.msg("[LogicModifier '{}']", theName, indent=2)
         logicKey = exporter.mgr.find_create_key(plLogicModifier, name=theName, so=so)
         logicmod = logicKey.object
         logicmod.setLogicFlag(plLogicModifier.kMultiTrigger, True)
         logicmod.notify = self.generate_notify_msg(exporter, so, "satisfies")
 
         # Now, the detector objects
-        print("        [ObjectInVolumeDetector '{}']".format(theName))
+        exporter.report.msg("[ObjectInVolumeDetector '{}']", theName, indent=2)
         detKey = exporter.mgr.find_create_key(plObjectInVolumeDetector, name=theName, so=so)
         det = detKey.object
 
-        print("        [VolumeSensorConditionalObject '{}']".format(theName))
+        exporter.report.msg("[VolumeSensorConditionalObject '{}']", theName, indent=2)
         volKey = exporter.mgr.find_create_key(plVolumeSensorConditionalObject, name=theName, so=so)
         volsens = volKey.object
 

--- a/korman/operators/op_export.py
+++ b/korman/operators/op_export.py
@@ -45,6 +45,10 @@ class ExportOperator(bpy.types.Operator):
                                    "description": "Version of the Plasma Engine to target",
                                    "default": "pvPots",  # This should be changed when moul is easier to target!
                                    "items": game_versions}),
+
+        "verbose": (BoolProperty, {"name": "Display Verbose Log",
+                                   "description": "Shows the verbose export log in the console",
+                                   "default": False}),
     }
 
     # This wigs out and very bad things happen if it's not directly on the operator...
@@ -58,6 +62,7 @@ class ExportOperator(bpy.types.Operator):
         # The crazy mess we're doing with props on the fly means we have to explicitly draw them :(
         layout.prop(age, "version")
         layout.prop(age, "bake_lighting")
+        layout.prop(age, "verbose")
         layout.prop(age, "profile_export")
 
     def __getattr__(self, attr):

--- a/korman/operators/op_export.py
+++ b/korman/operators/op_export.py
@@ -22,6 +22,7 @@ import pstats
 from .. import exporter
 from ..properties.prop_world import PlasmaAge
 from ..properties.modifiers.logic import game_versions
+from ..korlib import ConsoleToggler
 
 class ExportOperator(bpy.types.Operator):
     """Exports ages for Cyan Worlds' Plasma Engine"""
@@ -49,6 +50,10 @@ class ExportOperator(bpy.types.Operator):
         "verbose": (BoolProperty, {"name": "Display Verbose Log",
                                    "description": "Shows the verbose export log in the console",
                                    "default": False}),
+
+        "show_console": (BoolProperty, {"name": "Display Log Console",
+                                        "description": "Forces the Blender System Console open during the export",
+                                        "default": True}),
     }
 
     # This wigs out and very bad things happen if it's not directly on the operator...
@@ -62,6 +67,9 @@ class ExportOperator(bpy.types.Operator):
         # The crazy mess we're doing with props on the fly means we have to explicitly draw them :(
         layout.prop(age, "version")
         layout.prop(age, "bake_lighting")
+        row = layout.row()
+        row.enabled = ConsoleToggler.is_platform_supported()
+        row.prop(age, "show_console")
         layout.prop(age, "verbose")
         layout.prop(age, "profile_export")
 

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -427,10 +427,10 @@ class PlasmaVisControl(PlasmaModifierProperties):
         else:
             this_sv = bo.plasma_modifiers.softvolume
             if this_sv.enabled:
-                print("    [VisRegion] I'm a SoftVolume myself :)")
+                exporter.report.msg("[VisRegion] I'm a SoftVolume myself :)", indent=1)
                 rgn.region = this_sv.get_key(exporter, so)
             else:
-                print("    [VisRegion] SoftVolume '{}'".format(self.softvolume))
+                exporter.report.msg("[VisRegion] SoftVolume '{}'", self.softvolume, indent=1)
                 sv_bo = bpy.data.objects.get(self.softvolume, None)
                 if sv_bo is None:
                     raise ExportError("'{}': Invalid object '{}' for VisControl soft volume".format(bo.name, self.softvolume))

--- a/korman/properties/modifiers/sound.py
+++ b/korman/properties/modifiers/sound.py
@@ -173,7 +173,7 @@ class PlasmaSound(bpy.types.PropertyGroup):
             name = "Sfx-{}_{}".format(so.key.name, self.sound_data)
         else:
             name = "Sfx-{}_{}:{}".format(so.key.name, self.sound_data, channel)
-        print("    [{}] {}".format(pClass.__name__[2:], name))
+        exporter.report.msg("[{}] {}", pClass.__name__[2:], name, indent=1)
         sound = exporter.mgr.find_create_object(pClass, so=so, name=name)
 
         # If this object is a soft volume itself, we will use our own soft region.


### PR DESCRIPTION
A common complaint that I have heard (and have myself) is that there is little indication of what Korman is doing in the background. Unfortunately, there is no "easy" way to show progress in the Blender UI currently. Korman makes the assumption that nothing will touch Blender's context while it is executing. Attempts to move the exporter into a background thread such that Blender's UI remains active have all resulted in spectacular failures.

In PyPRP, the raw export log was dumped to the console, and many liked to watch it travel by as an indicator of progress. As such, I have implemented a progress monitor that outputs to the console into the export logger. The console now opens during the export (unless disabled in the export operator) to show the export progress. The export operator allows toggling between displaying the simplified progress monitor and the raw export log. If the console was closed before the export, it closes again once the export is finished, unless there is an error. If the console was open, it remains open.