### PR TITLE
Use Reflection Xform for env maps

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -520,7 +520,7 @@ class MaterialConverter:
 
             if layer is not None:
                 layer.UVWSrc = plLayerInterface.kUVWReflect
-                layer.state.miscFlags |= hsGMatState.kMiscUseRefractionXform
+                layer.state.miscFlags |= hsGMatState.kMiscUseReflectionXform
 
         # Because we might be working with a multi-faced env map. It's even worse than have two faces...
         for i in faces:


### PR DESCRIPTION
Refraction Xform causes the camera movement to affect the resulting output differently, leading to an envmap that seems to run around the object in the opposite direction as you turn.

Reflection Xform keeps it much more steady, and also matches what PlasmaMax outputs by default (they have a checkbox to use Refract mode).