### PR TITLE
Fix __exit__ binding to wrong method, ...

### DIFF
--- a/korlib/CMakeLists.txt
+++ b/korlib/CMakeLists.txt
@@ -12,6 +12,10 @@ find_package(OpenGL REQUIRED)
 find_package(string_theory REQUIRED)
 find_package(Vorbis REQUIRED)
 
+if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-parameter ${CMAKE_CXX_FLAGS}")
+endif()
+
 # Da files
 set(korlib_HEADERS
     buffer.h

--- a/korlib/texture.cpp
+++ b/korlib/texture.cpp
@@ -368,7 +368,7 @@ static PyObject* pyGLTexture_store_in_mipmap(pyGLTexture* self, PyObject* args) 
 
 static PyMethodDef pyGLTexture_Methods[] = {
     { _pycs("__enter__"), (PyCFunction)pyGLTexture__enter__, METH_NOARGS, NULL },
-    { _pycs("__exit__"), (PyCFunction)pyGLTexture__enter__, METH_VARARGS, NULL },
+    { _pycs("__exit__"), (PyCFunction)pyGLTexture__exit__, METH_VARARGS, NULL },
 
     { _pycs("generate_mipmap"), (PyCFunction)pyGLTexture_generate_mipmap, METH_NOARGS, NULL },
     { _pycs("get_level_data"), (PyCFunction)pyGLTexture_get_level_data, METH_KEYWORDS | METH_VARARGS, NULL },


### PR DESCRIPTION
... and enable the GCC warnings that could catch this kind of thing (unused static function).