### PR TITLE
Decal Material support

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -328,6 +328,9 @@ class MaterialConverter:
                 state.ZFlags |= hsGMatState.kZNoZRead
             if layer_props.skip_depth_write:
                 state.ZFlags |= hsGMatState.kZNoZWrite
+            if layer_props.decal:
+                hsgmat.compFlags |= hsGMaterial.kCompDecal
+                state.ZFlags |= hsGMatState.kZIncLayer | hsGMatState.kZNoZWrite
 
         # Export the specific texture type
         self._tex_exporters[texture.type](bo, layer, slot)

--- a/korman/properties/prop_texture.py
+++ b/korman/properties/prop_texture.py
@@ -95,3 +95,7 @@ class PlasmaLayer(bpy.types.PropertyGroup):
                                     description="Don't save the depth information, allowing rendering of layers behind this one",
                                     default=False,
                                     options=set())
+    decal = BoolProperty(name="Decal",
+                         description="Render on top of parent surface",
+                         default=False,
+                         options=set())

--- a/korman/ui/ui_texture.py
+++ b/korman/ui/ui_texture.py
@@ -71,6 +71,7 @@ class PlasmaLayerPanel(TextureButtonsPanel, bpy.types.Panel):
         col.label("Miscellaneous:")
         col.active = not slot.use_stencil
         col.prop(layer_props, "opacity", text="Opacity")
+        col.prop(layer_props, "decal")
 
         col = split.column()
         col.label("Z Depth:")

--- a/korman/ui/ui_texture.py
+++ b/korman/ui/ui_texture.py
@@ -68,22 +68,11 @@ class PlasmaLayerPanel(TextureButtonsPanel, bpy.types.Panel):
 
         split = layout.split()
         col = split.column()
-        col.label("Animation:")
-        col.active = self._has_animation_data(context) and not slot.use_stencil
-        col.prop(layer_props, "anim_auto_start")
-        col.prop(layer_props, "anim_loop")
-        col.separator()
-        col.label("SDL Animation:")
-        col.prop(layer_props, "anim_sdl_var", text="")
-
-        col = split.column()
         col.label("Miscellaneous:")
         col.active = not slot.use_stencil
         col.prop(layer_props, "opacity", text="Opacity")
-        col.separator()
 
-        col = col.column()
-        col.enabled = True
+        col = split.column()
         col.label("Z Depth:")
         col.prop(layer_props, "alpha_halo")
         col.prop(layer_props, "skip_depth_write")
@@ -103,6 +92,18 @@ class PlasmaLayerPanel(TextureButtonsPanel, bpy.types.Panel):
         col.label(text="")
         col.prop(layer_props, "detail_opacity_start")
         col.prop(layer_props, "detail_opacity_stop")
+
+        split = layout.split()
+        col = split.column()
+        col.label("Animation:")
+        col.active = self._has_animation_data(context) and not slot.use_stencil
+        col.prop(layer_props, "anim_auto_start")
+        col.prop(layer_props, "anim_loop")
+        col = split.column()
+        col.label("")
+        col.label("SDL Animation:")
+        col.active = self._has_animation_data(context) and not slot.use_stencil
+        col.prop(layer_props, "anim_sdl_var", text="")
 
     def _has_animation_data(self, context):
         tex = getattr(context, "texture", None)


### PR DESCRIPTION
Decals require 3 things:

* Co-incident geometry that is parented to the main mesh (not currently enforced, but we could warn if you export a decal layer on an object with no parent)
* A material with the CompDecal flag
* Layers with ZIncLayer and NoZWrite

This also reorganizes the layout of the layer properties so provide better grouping:
![screenshot from 2017-12-10 22-42-04](https://user-images.githubusercontent.com/241708/33818724-60deb962-ddfb-11e7-808a-4f97181dd7cb.png)
