### PR TITLE
Sort spans for opacity modifiers

### DIFF
--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -83,7 +83,7 @@ class _DrawableCriteria:
                 if mod.requires_face_sort:
                     self.criteria |= plDrawable.kCritSortFaces
                 if mod.requires_span_sort:
-                    self.sort_spans |= plDrawable.kCritSortSpans
+                    self.criteria |= plDrawable.kCritSortSpans
         self.render_level = _RenderLevel(bo, hsgmat, pass_index, self.blend_span)
 
     def __eq__(self, other):

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -81,6 +81,10 @@ class PlasmaFadeMod(PlasmaModifierProperties):
             mod.farOpaq = self.far_opaq
             mod.farTrans = self.far_trans
 
+    @property
+    def requires_span_sort(self):
+        return True
+
 
 class PlasmaFollowMod(idprops.IDPropObjectMixin, PlasmaModifierProperties):
     pl_id = "followmod"


### PR DESCRIPTION
Not 100% sure about this, but it was needed in my case to get a lamp flare to render without haloing (in combination with a passIndex to force it into a new BlendSpan).

This is where more rendering modifiers might make sense...