### PR TITLE
Fix Span/BlendSpan discriminator

### DIFF
--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -70,14 +70,9 @@ class _RenderLevel:
 
 class _DrawableCriteria:
     def __init__(self, bo, hsgmat, pass_index):
-        for layer in hsgmat.layers:
-            if layer.object.state.blendFlags & hsGMatState.kBlendMask:
-                self.blend_span = True
-                break
-        else:
-            self.blend_span = False
-
+        self.blend_span = hsgmat.layers[0].object.state.blendFlags & hsGMatState.kBlendMask
         self.criteria = 0
+
         if self.blend_span:
             for mod in bo.plasma_modifiers.modifiers:
                 if mod.requires_face_sort:


### PR DESCRIPTION
We're only a BlendSpan if the *first* layer of a material has a blend. Other layers are permitted to have blend modes, because those don't affect the blending of the span itself against other spans.

This matches the behaviour of PlasmaMax:
https://github.com/H-uru/Plasma/blob/42c4acbc9d2ddf7e0d4486ba3edfdd6c40e2f84b/Sources/Tools/MaxConvert/plMeshConverter.cpp#L1205-L1210