### PR TITLE
Don't set multiple exclusive blend flags

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -330,7 +330,7 @@ class MaterialConverter:
         else:
             layer_props = texture.plasma_layer
             layer.opacity = layer_props.opacity / 100
-            if layer_props.opacity < 100:
+            if layer_props.opacity < 100 and not state.blendFlags & hsGMatState.kBlendMask:
                 state.blendFlags |= hsGMatState.kBlendAlpha
             if layer_props.alpha_halo:
                 state.blendFlags |= hsGMatState.kBlendAlphaTestHigh


### PR DESCRIPTION
This causes the layer to just be entirely transparent.