### PR TITLE
Fix ladder detector regions for PotS exports.

### DIFF
--- a/korman/properties/modifiers/avatar.py
+++ b/korman/properties/modifiers/avatar.py
@@ -77,6 +77,10 @@ class PlasmaLadderModifier(PlasmaModifierProperties):
         simIface, physical = exporter.physics.generate_physical(bo, so, bounds, det_name)
         physical.memberGroup = plSimDefs.kGroupDetector
         physical.reportGroup |= 1 << plSimDefs.kGroupAvatar
+        physical.setProperty(plSimulationInterface.kPinned, True)
+        simIface.setProperty(plSimulationInterface.kPinned, True)
+        if physical.mass == 0.0:
+            physical.mass = 1.0
 
     @property
     def requires_actor(self):


### PR DESCRIPTION
Apparently pre-MOUL ladders can't have massless regions as detectors anywhere but at the origin, so this adds the required values to make sure the export puts each one in the correct location in PotS.

Fixes #93.