### PR TITLE
Fix #76

### DIFF
--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -213,7 +213,9 @@ class PlasmaLightMapGen(idprops.IDPropMixin, PlasmaModifierProperties):
             mat.addPiggyBack(layer.key)
 
             # Mmm... cheating
-            mat_mgr.export_prepared_layer(layer, lightmap_im)
+            mat_mgr.export_prepared_image(owner=layer, image=lightmap_im,
+                                          allowed_formats={"PNG", "DDS"},
+                                          indent=2)
 
     @classmethod
     def _idprop_mapping(cls):


### PR DESCRIPTION
On the surface, this allows lightmaps to be exported as PNGs. However, it also includes a light refactor of image exporting to facilitate requesting export formats and the targeting of plImageLibMod. This should better enable #96.