### PR TITLE
Fix #106

### DIFF
--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -112,12 +112,13 @@ class Exporter:
         oven.bake_static_lighting(self._objects)
 
     def _collect_objects(self):
+        scene = bpy.context.scene
         self.report.progress_advance()
-        self.report.progress_range = len(bpy.data.objects)
+        self.report.progress_range = len(scene.objects)
         inc_progress = self.report.progress_increment
 
         # Grab a naive listing of enabled pages
-        age = bpy.context.scene.world.plasma_age
+        age = scene.world.plasma_age
         pages_enabled = frozenset([page.name for page in age.pages if page.enabled])
         all_pages = frozenset([page.name for page in age.pages])
 
@@ -139,7 +140,7 @@ class Exporter:
         #     - Any arbitrary page can be disabled, so check our frozenset.
         #     - Also, someone might have specified an invalid page, so keep track of that.
         error = explosions.UndefinedPageError()
-        for obj in bpy.data.objects:
+        for obj in scene.objects:
             if obj.plasma_object.enabled:
                 page = obj.plasma_object.page
                 if not page and not default_inited:

--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -167,7 +167,7 @@ class LightBaker(_MeshManager):
 
             if user_lg is None:
                 if not lg or bool(lg.objects) is False:
-                    source = [i for i in bpy.data.objects if i.type == "LAMP"]
+                    source = [i for i in bpy.context.scene.objects if i.type == "LAMP"]
                 else:
                     source = lg.objects
                 dest = bpy.data.groups.new("_LIGHTMAPGEN_{}_{}".format(bo.name, mat_name))

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -128,15 +128,15 @@ class _MeshManager:
         return props
 
     def __enter__(self):
+        scene = bpy.context.scene
         self._report.progress_advance()
-        self._report.progress_range = len(bpy.data.objects)
+        self._report.progress_range = len(scene.objects)
 
         # Some modifiers like "Array" will procedurally generate new geometry that will impact
         # lightmap generation. The Blender Internal renderer does not seem to be smart enough to
         # take this into account. Thus, we temporarily apply modifiers to ALL meshes (even ones that
         # are not exported) such that we can generate proper lighting.
-        scene = bpy.context.scene
-        for i in bpy.data.objects:
+        for i in scene.objects:
             if i.type == "MESH" and i.is_modified(scene, "RENDER"):
                 # Remember, storing actual pointers to the Blender objects can cause bad things to
                 # happen because Blender's memory management SUCKS!


### PR DESCRIPTION
Given that the Plasma World (read: age) is defined per scene, it seems appropriate to limit the export to the current scene. Other scenes could potentially have other age definitions...