### PR TITLE
Add named lightmap passes

### DIFF
--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -61,7 +61,7 @@ class Exporter:
             self.mesh.add_progress_presteps(self.report)
             self.report.progress_add_step("Collecting Objects")
             self.report.progress_add_step("Harvesting Actors")
-            if self._op.bake_lighting:
+            if self._op.lighting_method != "skip":
                 etlight.LightBaker.add_progress_steps(self.report)
             self.report.progress_add_step("Exporting Scene Objects")
             self.report.progress_add_step("Exporting Logic Nodes")
@@ -86,8 +86,7 @@ class Exporter:
 
                 # Step 2.9: It is assumed that static lighting is available for the mesh exporter.
                 #           Indeed, in PyPRP it was a manual step. So... BAKE NAO!
-                if self._op.bake_lighting:
-                    self._bake_static_lighting()
+                self._bake_static_lighting()
 
                 # Step 3: Export all the things!
                 self._export_scene_objects()
@@ -113,8 +112,10 @@ class Exporter:
                 self.report.save()
 
     def _bake_static_lighting(self):
-        oven = etlight.LightBaker(self.report)
-        oven.bake_static_lighting(self._objects)
+        lighting_method = self._op.lighting_method
+        if lighting_method != "skip":
+            oven = etlight.LightBaker(self.report)
+            oven.bake_static_lighting(self._objects)
 
     def _collect_objects(self):
         scene = bpy.context.scene

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -195,7 +195,8 @@ class MeshConverter(_MeshManager):
 
         # Lightmapping requires its own LIGHTMAPGEN channel
         # NOTE: the LIGHTMAPGEN texture has already been created, so it is in num_user_texs
-        if bo.plasma_modifiers.lightmap.enabled:
+        lm = bo.plasma_modifiers.lightmap
+        if lm.enabled and lm.bake_type == "lightmap":
             num_user_texs -= 1
             max_user_texs -= 1
 
@@ -261,12 +262,13 @@ class MeshConverter(_MeshManager):
         bumpmap = self.material.get_bump_layer(bo)
 
         # Locate relevant vertex color layers now...
+        lm = bo.plasma_modifiers.lightmap
         color, alpha = None, None
         for vcol_layer in mesh.tessface_vertex_colors:
             name = vcol_layer.name.lower()
             if name in _VERTEX_COLOR_LAYERS:
                 color = vcol_layer.data
-            elif name == "autocolor" and color is None and not bo.plasma_modifiers.lightmap.enabled:
+            elif name == "autocolor" and color is None and not lm.bake_lightmap:
                 color = vcol_layer.data
             elif name == "alpha":
                 alpha = vcol_layer.data

--- a/korman/properties/__init__.py
+++ b/korman/properties/__init__.py
@@ -20,6 +20,7 @@ from .prop_image import *
 from .prop_lamp import *
 from . import modifiers
 from .prop_object import *
+from .prop_scene import *
 from .prop_texture import *
 from .prop_world import *
 
@@ -30,6 +31,7 @@ def register():
     bpy.types.Lamp.plasma_lamp = bpy.props.PointerProperty(type=PlasmaLamp)
     bpy.types.Object.plasma_net = bpy.props.PointerProperty(type=PlasmaNet)
     bpy.types.Object.plasma_object = bpy.props.PointerProperty(type=PlasmaObject)
+    bpy.types.Scene.plasma_scene = bpy.props.PointerProperty(type=PlasmaScene)
     bpy.types.Texture.plasma_layer = bpy.props.PointerProperty(type=PlasmaLayer)
     bpy.types.World.plasma_age = bpy.props.PointerProperty(type=PlasmaAge)
     bpy.types.World.plasma_fni = bpy.props.PointerProperty(type=PlasmaFni)

--- a/korman/properties/prop_scene.py
+++ b/korman/properties/prop_scene.py
@@ -1,0 +1,46 @@
+#    This file is part of Korman.
+#
+#    Korman is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Korman is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
+
+import bpy
+from bpy.props import *
+
+from ..exporter.etlight import _NUM_RENDER_LAYERS
+
+class PlasmaBakePass(bpy.types.PropertyGroup):
+    def _get_display_name(self):
+        return self.name
+    def _set_display_name(self, value):
+        for i in bpy.data.objects:
+            lm = i.plasma_modifiers.lightmap
+            if lm.bake_pass_name == self.name:
+                lm.bake_pass_name = value
+        self.name = value
+
+    display_name = StringProperty(name="Pass Name",
+                                  get=_get_display_name,
+                                  set=_set_display_name,
+                                  options=set())
+
+    render_layers = BoolVectorProperty(name="Layers to Bake",
+                                       description="Render layers to use for baking",
+                                       options=set(),
+                                       subtype="LAYER",
+                                       size=_NUM_RENDER_LAYERS,
+                                       default=((True,) * _NUM_RENDER_LAYERS))
+
+
+class PlasmaScene(bpy.types.PropertyGroup):
+    bake_passes = CollectionProperty(type=PlasmaBakePass)
+    active_pass_index = IntProperty(options={"HIDDEN"})

--- a/korman/ui/__init__.py
+++ b/korman/ui/__init__.py
@@ -20,6 +20,7 @@ from .ui_list import *
 from .ui_menus import *
 from .ui_modifiers import *
 from .ui_object import *
+from .ui_render_layer import *
 from .ui_texture import *
 from .ui_toolbox import *
 from .ui_world import *

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -84,8 +84,9 @@ def lighting(modifier, layout, context):
         col.label("No static lights will be baked.", icon="LAYER_USED")
 
 def lightmap(modifier, layout, context):
+    pl_scene = context.scene.plasma_scene
     layout.row(align=True).prop(modifier, "quality", expand=True)
-    layout.prop(modifier, "render_layers", text="Active Render Layers")
+    layout.prop_search(modifier, "bake_pass_name", pl_scene, "bake_passes", icon="RENDERLAYERS")
     layout.prop(modifier, "lights")
     layout.prop_search(modifier, "uv_map", context.active_object.data, "uv_textures")
 

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -16,6 +16,7 @@
 import bpy
 
 from .. import ui_list
+from ...exporter.mesh import _VERTEX_COLOR_LAYERS
 
 def fademod(modifier, layout, context):
     layout.prop(modifier, "fader_type")
@@ -73,28 +74,42 @@ def lighting(modifier, layout, context):
     col.label("Other Plasma lights {} be cast at runtime.".format("will" if modifier.rt_lights else "will NOT"),
               icon="LAYER_USED")
 
+    map_type = "a lightmap" if lightmap.enabled and lightmap.bake_type == "lightmap" else "vertex colors"
     if lightmap.enabled and lightmap.lights:
-            col.label(" All '{}' lights will be baked to a lightmap".format(lightmap.lights),
+            col.label("All '{}' lights will be baked to {}".format(lightmap.lights.name, map_type),
                       icon="LAYER_USED")
     elif have_static_lights:
         light_type = "Blender-only" if modifier.rt_lights else "unanimated"
-        map_type = "a lightmap" if lightmap.enabled else "vertex colors"
         col.label("Other {} lights will be baked to {}.".format(light_type, map_type), icon="LAYER_USED")
     else:
         col.label("No static lights will be baked.", icon="LAYER_USED")
 
 def lightmap(modifier, layout, context):
     pl_scene = context.scene.plasma_scene
-    layout.row(align=True).prop(modifier, "quality", expand=True)
+    is_texture = modifier.bake_type == "lightmap"
+
+    layout.prop(modifier, "bake_type")
+    if modifier.bake_type == "vcol":
+        col_layer = next((i for i in modifier.id_data.data.vertex_colors if i.name.lower() in _VERTEX_COLOR_LAYERS), None)
+        if col_layer is not None:
+            layout.label("Mesh color layer '{}' will override this lighting.".format(col_layer.name), icon="ERROR")
+
+    col = layout.column()
+    col.active = is_texture
+    col.prop(modifier, "quality")
     layout.prop_search(modifier, "bake_pass_name", pl_scene, "bake_passes", icon="RENDERLAYERS")
     layout.prop(modifier, "lights")
-    layout.prop_search(modifier, "uv_map", context.active_object.data, "uv_textures")
+    col = layout.column()
+    col.active = is_texture
+    col.prop_search(modifier, "uv_map", context.active_object.data, "uv_textures")
 
     # Lightmaps can only be applied to objects with opaque materials.
-    if any((i.use_transparency for i in modifier.id_data.data.materials if i is not None)):
+    if is_texture and any((i.use_transparency for i in modifier.id_data.data.materials if i is not None)):
         layout.label("Transparent objects cannot be lightmapped.", icon="ERROR")
     else:
-        operator = layout.operator("object.plasma_lightmap_preview", "Preview Lightmap", icon="RENDER_STILL")
+        col = layout.column()
+        col.active = is_texture
+        operator = col.operator("object.plasma_lightmap_preview", "Preview Lightmap", icon="RENDER_STILL")
 
         # Kind of clever stuff to show the user a preview...
         # We can't show images, so we make a hidden ImageTexture called LIGHTMAPGEN_PREVIEW. We check

--- a/korman/ui/ui_render_layer.py
+++ b/korman/ui/ui_render_layer.py
@@ -1,0 +1,53 @@
+#    This file is part of Korman.
+#
+#    Korman is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Korman is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
+
+import bpy
+from . import ui_list
+
+class RenderLayerButtonsPanel:
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "render_layer"
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.render.engine == "PLASMA_GAME"
+
+
+class BakePassUI(bpy.types.UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_property, index=0, flt_flag=0):
+        layout.prop(item, "display_name", emboss=False, text="", icon="RENDERLAYERS")
+
+
+class PlasmaBakePassPanel(RenderLayerButtonsPanel, bpy.types.Panel):
+    bl_label = "Plasma Bake Passes"
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene.plasma_scene
+
+        ui_list.draw_list(layout, "BakePassUI", "scene", scene, "bake_passes",
+                          "active_pass_index",  name_prefix="Pass",
+                          name_prop="display_name", rows=3, maxrows=3)
+
+        active_pass_index = scene.active_pass_index
+        try:
+            bake_pass = scene.bake_passes[active_pass_index]
+        except:
+            pass
+        else:
+            box = layout.box()
+            box.prop(bake_pass, "display_name")
+            box.prop(bake_pass, "render_layers")

--- a/korman/ui/ui_world.py
+++ b/korman/ui/ui_world.py
@@ -133,18 +133,18 @@ class PlasmaAgePanel(AgeButtonsPanel, bpy.types.Panel):
 
         col = split.column()
         col.label("Export Settings:")
-        col.prop(age, "texcache_method", text="")
-        col.prop(age, "bake_lighting")
-        cons_ui = col.column()
-        cons_ui.enabled = ConsoleToggler.is_platform_supported()
-        cons_ui.prop(age, "verbose")
-        cons_ui.prop(age, "show_console")
+        col.enabled = ConsoleToggler.is_platform_supported()
+        col.prop(age, "verbose")
+        col.prop(age, "show_console")
 
         col = split.column()
         col.label("Plasma Settings:")
         col.prop(age, "age_sdl")
         col.prop(age, "use_texture_page")
 
+        layout.separator()
+        layout.prop(age, "lighting_method")
+        layout.prop(age, "texcache_method")
 
 
 class PlasmaEnvironmentPanel(AgeButtonsPanel, bpy.types.Panel):


### PR DESCRIPTION
This fixes #118 by adding named lightmap passes. It is no longer possible to specify render layers on a per-object basis. Instead, a pass must be set up. Old modifiers are silently upgraded and consolidated into passes when the blend file is loaded. The old default behavior is equivalent to specifying no pass on the new modifier.

Additionally, I have generalized the lightmap modifier by allowing the artist to change to vertex shading mode and specify the layers to bake with. The "bake static lighting" checkbox has been changed to a dropdown in which light baking can be turned off completely, all lightmaps can be forced to vertex colors, all arist-specified vertex colors can be forced to lightmaps, or the blissful default. I did not add the option to force auto-vertex colors to lightmaps, which I suppose could be interesting in some situations...