### PR TITLE
Environment Map Improvements

### DIFF
--- a/korlib/korlib.h
+++ b/korlib/korlib.h
@@ -23,6 +23,7 @@
 #include <Python.h>
 
 #define _pycs(x) const_cast<char*>(x)
+#define arrsize(a) (sizeof(a) / sizeof((a)[0]))
 
 class PyObjectRef {
     PyObject* m_object;

--- a/korlib/korlib.h
+++ b/korlib/korlib.h
@@ -29,6 +29,7 @@ class PyObjectRef {
     PyObject* m_object;
 
 public:
+    PyObjectRef() : m_object() { }
     PyObjectRef(PyObject* o) : m_object(o) { }
     ~PyObjectRef() { Py_XDECREF(m_object); }
 

--- a/korlib/module.cpp
+++ b/korlib/module.cpp
@@ -23,6 +23,7 @@ extern "C" {
 static PyMethodDef korlib_Methods[] = {
     { _pycs("create_bump_LUT"), (PyCFunction)create_bump_LUT, METH_VARARGS, NULL },
     { _pycs("inspect_vorbisfile"), (PyCFunction)inspect_vorbisfile, METH_VARARGS, NULL },
+    { _pycs("scale_image"), (PyCFunction)scale_image, METH_KEYWORDS | METH_VARARGS, NULL },
 
     { NULL, NULL, 0, NULL },
 };

--- a/korlib/texture.h
+++ b/korlib/texture.h
@@ -21,6 +21,8 @@
 
 extern "C" {
 
+PyObject* scale_image(PyObject*, PyObject*, PyObject*);
+
 extern PyTypeObject pyGLTexture_Type;
 PyObject* Init_pyGLTexture_Type();
 

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -351,6 +351,10 @@ class Exporter:
         self.image.save()
 
     @property
+    def envmap_method(self):
+        return bpy.context.scene.world.plasma_age.envmap_method
+
+    @property
     def texcache_path(self):
         age = bpy.context.scene.world.plasma_age
         filepath = age.texcache_path

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -84,13 +84,14 @@ class _Texture:
         self.extension = kwargs.get("extension", self.auto_ext)
         self.ephemeral = kwargs.get("ephemeral", False)
         self.image = image
+        self.tag = kwargs.get("tag", None)
 
     def __eq__(self, other):
         if not isinstance(other, _Texture):
             return False
 
         # Yeah, the string name is a unique identifier. So shoot me.
-        if str(self) == str(other):
+        if str(self) == str(other) and self.tag == other.tag:
             self._update(other)
             return True
         return False
@@ -692,6 +693,8 @@ class MaterialConverter:
            - indent: (optional) indentation level for log messages
                      default: 2
            - ephemeral: (optional) never cache this image
+           - tag: (optional) an optional identifier hint that allows multiple images with the
+                             same name to coexist in the cache
         """
         owner = kwargs.pop("owner", None)
         indent = kwargs.pop("indent", 2)
@@ -785,10 +788,10 @@ class MaterialConverter:
                         for i in range(numLevels):
                             mipmap.CompressImage(i, data[i])
                             data[i] = mipmap.getLevel(i)
-                    texcache.add_texture(key, numLevels, (eWidth, eHeight), compression, data)
+                    texcache.add_texture(key, numLevels, (eWidth, eHeight), compression, [data,])
                 else:
                     eWidth, eHeight = cached_image.export_size
-                    data = cached_image.image_data
+                    data = cached_image.image_data[0]
                     numLevels = cached_image.mip_levels            
 
                 # Now we poke our new bitmap into the pending layers. Note that we have to do some funny

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -28,8 +28,8 @@ _MAX_STENCILS = 6
 
 # Blender cube map mega image to libHSPlasma plCubicEnvironmap faces mapping...
 # See https://blender.stackexchange.com/questions/46891/how-to-render-an-environment-to-a-cube-map-in-cycles
-_BLENDER_CUBE_MAP = ("leftFace", "backFace", "rightFace",
-                     "bottomFace", "topFace", "frontFace")
+BLENDER_CUBE_MAP = ("leftFace", "backFace", "rightFace",
+                    "bottomFace", "topFace", "frontFace")
 
 class _Texture:
     _DETAIL_BLEND = {
@@ -810,7 +810,7 @@ class MaterialConverter:
                         if key.is_cube_map:
                             assert len(data) == 6
                             texture = plCubicEnvironmap(name)
-                            for face_name, face_data in zip(_BLENDER_CUBE_MAP, data):
+                            for face_name, face_data in zip(BLENDER_CUBE_MAP, data):
                                 for i in range(numLevels):
                                     mipmap.setLevel(i, face_data[i])
                                 setattr(texture, face_name, mipmap)
@@ -866,7 +866,7 @@ class MaterialConverter:
         #       According to my profiling, it takes roughly 0.7 seconds to process a
         #       cube map whose faces are 1024x1024 (3072x2048 total). Maybe a later
         #       commit will move this into korlib. We'll see.
-        face_num = len(_BLENDER_CUBE_MAP)
+        face_num = len(BLENDER_CUBE_MAP)
         face_images = [None] * face_num
         for i in range(face_num):
             col_id = i if i < 3 else i - 3
@@ -884,7 +884,7 @@ class MaterialConverter:
 
         # Now that we have our six faces, we'll toss them into the GLTexture helper
         # to generate mipmaps, if needed...
-        for i, face_name in enumerate(_BLENDER_CUBE_MAP):
+        for i, face_name in enumerate(BLENDER_CUBE_MAP):
             glimage = GLTexture(key)
             glimage.image_data = fWidth, fHeight, face_images[i]
             eWidth, eHeight = glimage.size_pot

--- a/korman/helpers.py
+++ b/korman/helpers.py
@@ -39,7 +39,7 @@ class TemporaryObject:
         self._remove_func = remove_func
 
     def __enter__(self):
-        return self
+        return self._obj
 
     def __exit__(self, type, value, traceback):
         self._remove_func(self._obj)

--- a/korman/korlib/texture.py
+++ b/korman/korlib/texture.py
@@ -27,7 +27,7 @@ TEX_DETAIL_ALPHA = 0
 TEX_DETAIL_ADD = 1
 TEX_DETAIL_MULTIPLY = 2
 
-def _scale_image(buf, srcW, srcH, dstW, dstH):
+def scale_image(buf, srcW, srcH, dstW, dstH):
     """Scales an RGBA image using the algorithm from CWE's plMipmap::ScaleNicely"""
     dst, dst_idx = bytearray(dstW * dstH * 4), 0
     scaleX, scaleY = (srcW / dstW), (srcH / dstH)
@@ -228,6 +228,12 @@ class GLTexture:
             if data[i] != 255:
                 return True
         return False
+
+    def _get_image_data(self):
+        return (self._width, self._height, self._image_data)
+    def _set_image_data(self, value):
+        self._width, self._height, self._image_data = value
+    image_data = property(_get_image_data, _set_image_data)
 
     def _invert_image(self, width, height, buf):
         size = width * height * 4

--- a/korman/korlib/texture.py
+++ b/korman/korlib/texture.py
@@ -96,14 +96,15 @@ def scale_image(buf, srcW, srcH, dstW, dstH):
 
 
 class GLTexture:
-    def __init__(self, texkey=None, bgra=False, fast=False):
+    def __init__(self, texkey=None, image=None, bgra=False, fast=False):
+        assert texkey or image
         self._texkey = texkey
+        if texkey is not None:
+            self._blimg = texkey.image
+        if image is not None:
+            self._blimg = image
         self._image_inverted = fast
         self._bgra = bgra
-
-    @property
-    def _blimg(self):
-        return self._texkey.image
 
     def __enter__(self):
         """Loads the image data using OpenGL"""
@@ -186,7 +187,7 @@ class GLTexture:
             buf = self._invert_image(eWidth, eHeight, buf)
 
         # If this is a detail map, then we need to bake that per-level here.
-        if self._texkey.is_detail_map:
+        if self._texkey is not None and self._texkey.is_detail_map:
             detail_blend = self._texkey.detail_blend
             if detail_blend == TEX_DETAIL_ALPHA:
                 self._make_detail_map_alpha(buf, level)

--- a/korman/korlib/texture.py
+++ b/korman/korlib/texture.py
@@ -160,7 +160,7 @@ class GLTexture:
         # Previously, we would leave the texture bound in OpenGL and use it to do the mipmapping, using
         # old, deprecated OpenGL features. With the introduction of plCubicEnvironmap support to Korman,
         # we wind up needing to get an NPOT image from OpenGL. Unfortunately, Blender will sometimes scale
-        # images to be POT _before_ loading them into OpenGL. Thereofre, we now use OpenGL to grab the first
+        # images to be POT _before_ loading them into OpenGL. Therefore, we now use OpenGL to grab the first
         # level, then scale down to the new level from there.
         oWidth, oHeight = self.size_npot
         eWidth = ensure_power_of_two(oWidth) >> level

--- a/korman/korlib/texture.py
+++ b/korman/korlib/texture.py
@@ -13,12 +13,13 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
 
+import array
 import bgl
+from ..helpers import ensure_power_of_two
 import math
 from PyHSPlasma import plBitmap
 
 # BGL doesn't know about this as of Blender 2.74
-bgl.GL_GENERATE_MIPMAP = 0x8191
 bgl.GL_BGRA = 0x80E1
 
 # Some texture generation flags
@@ -26,35 +27,121 @@ TEX_DETAIL_ALPHA = 0
 TEX_DETAIL_ADD = 1
 TEX_DETAIL_MULTIPLY = 2
 
+def _scale_image(buf, srcW, srcH, dstW, dstH):
+    """Scales an RGBA image using the algorithm from CWE's plMipmap::ScaleNicely"""
+    dst, dst_idx = bytearray(dstW * dstH * 4), 0
+    scaleX, scaleY = (srcW / dstW), (srcH / dstH)
+    filterW, filterH = max(scaleX, 1.0), max(scaleY, 1.0)
+
+    src_rowspan = srcW * 4
+    weightsY = array.array("f", [0.0] * 16)
+    weightsX = array.array("f", [0.0] * 16)
+
+    # I hope you're in no particular hurry...
+    for dstY in range(dstH):
+        srcY = dstY * scaleY
+        srcY_start = int(max(srcY - filterH, 0))
+        srcY_end = int(min(srcY + filterH, srcH - 1))
+
+        #weightsY = { i - srcY_start: 1.0 - abs(i - srcY) / scaleY \
+        #             for i in range(srcY_start, srcY_end+1, 1) if i - srcY_start < 16 }
+        for i in range(16):
+            idx = i + srcY_start
+            if idx > srcY_end:
+                break
+            weightsY[i] = 1.0 - abs(idx - srcY) / filterH
+
+        for dstX in range(dstW):
+            srcX = dstX * scaleX
+            srcX_start = int(max(srcX - filterW, 0))
+            srcX_end = int(min(srcX + filterW, srcW - 1))
+
+            #weightsX = { i - srcX_start: 1.0 - abs(i - srcX) / scaleX \
+            #             for i in range(srcX_start, srcX_end+1, 1) if i - srcX_start < 16 }
+            for i in range(16):
+                idx = i + srcX_start
+                if idx > srcX_end:
+                    break
+                weightsX[i] = 1.0 - abs(idx - srcX) / filterW
+
+            accum_color = [0.0, 0.0, 0.0, 0.0]
+            weight_total = 0.0
+            for i in range(srcY_start, srcY_end+1, 1):
+                weightY_idx = i - srcY_start
+                weightY = weightsY[weightY_idx] if weightY_idx < 16 else 1.0 - abs(i - srcY) / filterH
+                weightY = 1.0 - abs(i - srcY) / filterH
+
+                src_idx = (i * src_rowspan) + (srcX_start * 4)
+                for j in range(srcX_start, srcX_end+1, 1):
+                    weightX_idx = j - srcX_start
+                    weightX = weightsX[weightX_idx] if weightX_idx < 16 else 1.0 - abs(j - srcX) / filterW
+                    weight = weightY * weightX
+
+                    if weight > 0.0:
+                        # According to profiling, a list comprehension here doubles the execution time of this
+                        # function. I know this function is supposed to be slow, but dayum... I've unrolled it
+                        # to avoid all the extra allocations.
+                        for k in range(4):
+                            accum_color[k] = accum_color[k] + buf[src_idx+k] * weight
+                        weight_total += weight
+                    src_idx += 4
+
+            weight_total = max(weight_total, 0.0001)
+            for i in range(4):
+                accum_color[i] = int(accum_color[i] * (1.0 / weight_total))
+            dst[dst_idx:dst_idx+4] = accum_color
+            dst_idx += 4
+
+    return bytes(dst)
+
+
 class GLTexture:
-    def __init__(self, texkey=None):
+    def __init__(self, texkey=None, bgra=False, fast=False):
         self._texkey = texkey
-        self._ownit = (self._blimg.bindcode[0] == 0)
+        self._image_inverted = fast
+        self._bgra = bgra
 
     @property
     def _blimg(self):
         return self._texkey.image
 
     def __enter__(self):
-        """Sets the Blender Image as the active OpenGL texture"""
-        if self._ownit:
+        """Loads the image data using OpenGL"""
+
+        # Set image active in OpenGL
+        ownit = self._blimg.bindcode[0] == 0
+        if ownit:
             if self._blimg.gl_load() != 0:
                 raise RuntimeError("failed to load image")
-
-        self._previous_texture = self._get_integer(bgl.GL_TEXTURE_BINDING_2D)
-        self._changed_state = (self._previous_texture != self._blimg.bindcode[0])
-        if self._changed_state:
+        previous_texture = self._get_integer(bgl.GL_TEXTURE_BINDING_2D)
+        changed_state = (previous_texture != self._blimg.bindcode[0])
+        if changed_state:
             bgl.glBindTexture(bgl.GL_TEXTURE_2D, self._blimg.bindcode[0])
+
+        # Grab the image data
+        self._width = self._get_tex_param(bgl.GL_TEXTURE_WIDTH, 0)
+        self._height = self._get_tex_param(bgl.GL_TEXTURE_HEIGHT, 0)
+        size = self._width * self._height * 4
+        buf = bgl.Buffer(bgl.GL_BYTE, size)
+        fmt = bgl.GL_BGRA if self._bgra else bgl.GL_RGBA
+        bgl.glGetTexImage(bgl.GL_TEXTURE_2D, 0, fmt, bgl.GL_UNSIGNED_BYTE, buf)
+
+        # OpenGL returns the images upside down, so we're going to rotate it in memory.
+        # ... But only if requested... :)
+        if self._image_inverted:
+            self._image_data = bytes(buf)
+        else:
+            self._image_data = self._invert_image(self._width, self._height, buf)
+
+        # Restore previous OpenGL state
+        if changed_state:
+            bgl.glBindTexture(bgl.GL_TEXTURE_2D, previous_texture)
+        if ownit:
+            self._blimg.gl_free()
         return self
 
     def __exit__(self, type, value, traceback):
-        mipmap_state = getattr(self, "_mipmap_state", None)
-        if mipmap_state is not None:
-            bgl.glTexParameteri(bgl.GL_TEXTURE_2D, bgl.GL_GENERATE_MIPMAP, mipmap_state)
-        if self._changed_state:
-            bgl.glBindTexture(bgl.GL_TEXTURE_2D, self._previous_texture)
-        if self._ownit:
-            self._blimg.gl_free()
+        del self._image_data
 
     @property
     def _detail_falloff(self):
@@ -64,57 +151,55 @@ class GLTexture:
                  self._texkey.detail_opacity_start / 100.0,
                  self._texkey.detail_opacity_stop / 100.0)
 
-    def generate_mipmap(self):
-        """Generates all mip levels for this texture"""
-        self._mipmap_state = self._get_tex_param(bgl.GL_GENERATE_MIPMAP)
-
-        # Note that this is a very old feature from OpenGL 1.x -- it's new enough that Windows (and
-        # Blender apparently) don't support it natively and yet old enough that it was thrown away
-        # in OpenGL 3.0. The new way is glGenerateMipmap, but Blender likes oldgl, so we don't have that
-        # function available to us in BGL. I don't want to deal with loading the GL dll in ctypes on
-        # many platforms right now (or context headaches). If someone wants to fix this, be my guest!
-        # It will simplify our state tracking a bit.
-        bgl.glTexParameteri(bgl.GL_TEXTURE_2D, bgl.GL_GENERATE_MIPMAP, 1)
-
-    def get_level_data(self, level=0, calc_alpha=False, bgra=False, report=None, fast=False):
+    def get_level_data(self, level=0, calc_alpha=False, report=None, indent=2, fast=False):
         """Gets the uncompressed pixel data for a requested mip level, optionally calculating the alpha
            channel from the image color data
         """
-        width = self._get_tex_param(bgl.GL_TEXTURE_WIDTH, level)
-        height = self._get_tex_param(bgl.GL_TEXTURE_HEIGHT, level)
+
+        # Previously, we would leave the texture bound in OpenGL and use it to do the mipmapping, using
+        # old, deprecated OpenGL features. With the introduction of plCubicEnvironmap support to Korman,
+        # we wind up needing to get an NPOT image from OpenGL. Unfortunately, Blender will sometimes scale
+        # images to be POT _before_ loading them into OpenGL. Thereofre, we now use OpenGL to grab the first
+        # level, then scale down to the new level from there.
+        oWidth, oHeight = self.size_npot
+        eWidth = ensure_power_of_two(oWidth) >> level
+        eHeight = ensure_power_of_two(oHeight) >> level
+
         if report is not None:
-            report.msg("Level #{}: {}x{}", level, width, height, indent=2)
+            report.msg("Level #{}: {}x{}", level, eWidth, eHeight, indent=indent)
 
-        # Grab the image data
-        size = width * height * 4
-        buf = bgl.Buffer(bgl.GL_BYTE, size)
-        fmt = bgl.GL_BGRA if bgra else bgl.GL_RGBA
-        bgl.glGetTexImage(bgl.GL_TEXTURE_2D, level, fmt, bgl.GL_UNSIGNED_BYTE, buf);
+        # Scale, if needed...
+        if oWidth != eWidth or oHeight != eHeight:
+            buf = _scale_image(self._image_data, oWidth, oHeight, eWidth, eHeight)
+        else:
+            buf = self._image_data
+
+        # Some operations, like alpha testing, don't care about the fact that OpenGL flips
+        # the images in memory. Give an opportunity to bail here...
         if fast:
-            return bytes(buf)
+            return self._image_data
+        else:
+            buf = bytearray(self._image_data)
 
-        # OpenGL returns the images upside down, so we're going to rotate it in memory.
-        finalBuf = bytearray(size)
-        row_stride = width * 4
-        for i in range(height):
-            src, dst = i * row_stride, (height - (i+1)) * row_stride
-            finalBuf[dst:dst+row_stride] = buf[src:src+row_stride]
+
+        if self._image_inverted:
+            buf = self._invert_image(eWidth, eHeight, buf)
 
         # If this is a detail map, then we need to bake that per-level here.
         if self._texkey.is_detail_map:
             detail_blend = self._texkey.detail_blend
             if detail_blend == TEX_DETAIL_ALPHA:
-                self._make_detail_map_alpha(finalBuf, level)
+                self._make_detail_map_alpha(buf, level)
             elif detail_blend == TEX_DETAIL_ADD:
-                self._make_detail_map_alpha(finalBuf, level)
+                self._make_detail_map_alpha(buf, level)
             elif detail_blend == TEX_DETAIL_MULTIPLY:
-                self._make_detail_map_mult(finalBuf, level)
+                self._make_detail_map_mult(buf, level)
 
         # Do we need to calculate the alpha component?
         if calc_alpha:
             for i in range(0, size, 4):
-                finalBuf[i+3] = int(sum(finalBuf[i:i+3]) / 3)
-        return bytes(finalBuf)
+                buf[i+3] = int(sum(buf[i:i+3]) / 3)
+        return bytes(buf)
 
     def _get_detail_alpha(self, level, dropoff_start, dropoff_stop, detail_max, detail_min):
         alpha = (level - dropoff_start) * (detail_min - detail_max) / (dropoff_stop - dropoff_start) + detail_max
@@ -138,11 +223,20 @@ class GLTexture:
 
     @property
     def has_alpha(self):
-        data = self.get_level_data(report=None, fast=True)
+        data = self._image_data
         for i in range(3, len(data), 4):
             if data[i] != 255:
                 return True
         return False
+
+    def _invert_image(self, width, height, buf):
+        size = width * height * 4
+        finalBuf = bytearray(size)
+        row_stride = width * 4
+        for i in range(height):
+            src, dst = i * row_stride, (height - (i+1)) * row_stride
+            finalBuf[dst:dst+row_stride] = buf[src:src+row_stride]
+        return bytes(finalBuf)
 
     def _make_detail_map_add(self, data, level):
         dropoff_start, dropoff_stop, detail_max, detail_min = self._detail_falloff
@@ -167,7 +261,7 @@ class GLTexture:
 
     @property
     def num_levels(self):
-        numLevels = math.floor(math.log(max(self._blimg.size), 2)) + 1
+        numLevels = math.floor(math.log(max(self.size_npot), 2)) + 1
 
         # Major Workaround Ahoy
         # There is a bug in Cyan's level size algorithm that causes it to not allocate enough memory
@@ -181,3 +275,11 @@ class GLTexture:
         #                  texture in a single pixel?"
         # :)
         return max(numLevels - 2, 2)
+
+    @property
+    def size_npot(self):
+        return self._width, self._height
+
+    @property
+    def size_pot(self):
+        return ensure_power_of_two(self._width), ensure_power_of_two(self._height)

--- a/korman/operators/__init__.py
+++ b/korman/operators/__init__.py
@@ -14,6 +14,7 @@
 #    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
 
 from . import op_export as exporter
+from . import op_image as image
 from . import op_lightmap as lightmap
 from . import op_mesh as mesh
 from . import op_modifier as modifier

--- a/korman/operators/op_export.py
+++ b/korman/operators/op_export.py
@@ -66,7 +66,7 @@ class ExportOperator(bpy.types.Operator):
 
         "envmap_method": (EnumProperty, {"name": "Environment Maps",
                                          "description": "Environment Map Settings",
-                                         "items": [("skip", "Don't Export EnvMaps", "Environment Maps are not exported (the age runs faster)"),
+                                         "items": [("skip", "Don't Export EnvMaps", "Environment Maps are not exported"),
                                                    ("dcm2dem", "Downgrade Planar EnvMaps", "When the engine doesn't support them, Planar Environment Maps are downgraded to Cube Maps"),
                                                    ("perengine", "Export Supported EnvMaps", "Only environment maps supported by the selected game engine are exported")],
                                          "default": "dcm2dem"}),

--- a/korman/operators/op_export.py
+++ b/korman/operators/op_export.py
@@ -64,6 +64,13 @@ class ExportOperator(bpy.types.Operator):
                                                      ("force_lightmap", "Force Lightmap Bake", "All static lighting is baked as lightmaps (slower export)")],
                                            "default": "bake"}),
 
+        "envmap_method": (EnumProperty, {"name": "Environment Maps",
+                                         "description": "Environment Map Settings",
+                                         "items": [("skip", "Don't Export EnvMaps", "Environment Maps are not exported (the age runs faster)"),
+                                                   ("dcm2dem", "Downgrade Planar EnvMaps", "When the engine doesn't support them, Planar Environment Maps are downgraded to Cube Maps"),
+                                                   ("perengine", "Export Supported EnvMaps", "Only environment maps supported by the selected game engine are exported")],
+                                         "default": "dcm2dem"}),
+
         "export_active": (BoolProperty, {"name": "INTERNAL: Export currently running",
                                          "default": False,
                                          "options": {"SKIP_SAVE"}}),

--- a/korman/operators/op_image.py
+++ b/korman/operators/op_image.py
@@ -136,7 +136,7 @@ class PlasmaBuildCubeMapOperator(ImageOperator, bpy.types.Operator):
         self._report.progress_advance()
         self._report.msg("Generating cubemap image...")
 
-        # If a texture was provided, we should check to see if as have an image we can replace...
+        # If a texture was provided, we should check to see if we have an image we can replace...
         image = bpy.data.textures[self.texture_name].image if self.texture_name else None
 
         # Init our image

--- a/korman/operators/op_image.py
+++ b/korman/operators/op_image.py
@@ -1,0 +1,237 @@
+#    This file is part of Korman.
+#
+#    Korman is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Korman is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
+
+import bpy
+from bpy.props import *
+from pathlib import Path
+
+from ..helpers import TemporaryObject, ensure_power_of_two
+from ..korlib import ConsoleToggler, GLTexture, scale_image
+from ..exporter.explosions import *
+from ..exporter.logger import ExportProgressLogger
+from ..exporter.material import BLENDER_CUBE_MAP
+
+# These are some filename suffixes that we will check to match for the cubemap faces
+_CUBE_FACES = {
+    "leftFace": "LF",
+    "backFace": "BK",
+    "rightFace": "RT",
+    "bottomFace": "DN",
+    "topFace": "UP",
+    "frontFace": "FR",
+}
+
+class ImageOperator:
+    @classmethod
+    def poll(cls, context):
+        return context.scene.render.engine == "PLASMA_GAME"
+
+
+class PlasmaBuildCubeMapOperator(ImageOperator, bpy.types.Operator):
+    bl_idname = "image.plasma_build_cube_map"
+    bl_label = "Build Cubemap"
+    bl_description = "Builds a Blender cubemap from six images"
+
+    overwrite_existing = BoolProperty(name="Check Existing",
+                                      description="Checks for an existing image and overwrites it",
+                                      default=True,
+                                      options=set())
+    filepath = StringProperty(subtype="FILE_PATH")
+    require_cube = BoolProperty(name="Require Square Faces",
+                                description="Resize cubemap faces to be square if they are not",
+                                default=True,
+                                options=set())
+    texture_name = StringProperty(name="Texture",
+                                  description="Environment Map Texture to stuff this into",
+                                  default="",
+                                  options={"HIDDEN"})
+
+    def __init__(self):
+        self._report = ExportProgressLogger()
+        self._report.progress_add_step("Finding Face Images")
+        self._report.progress_add_step("Loading Face Images")
+        self._report.progress_add_step("Scaling Face Images")
+        self._report.progress_add_step("Generating Cube Map")
+
+    def execute(self, context):
+        with ConsoleToggler(True) as _:
+            try:
+                self._execute()
+            except ExportError as error:
+                self.report({"ERROR"}, str(error))
+                return {"CANCELLED"}
+            else:
+                return {"FINISHED"}
+
+    def _execute(self):
+        self._report.progress_start("BUILDING CUBE MAP")
+        if not Path(self.filepath).is_file():
+            raise ExportError("No cube image found at '{}'".format(self.filepath))
+
+        # Figure out the paths for the six cube faces. We will use the original file
+        # only if a face is missing...
+        face_image_paths = self._find_cube_files(self.filepath)
+
+        # If no images were loaded, that means we will want to generate a cube map
+        # with the single face provided by the image in filepath. Otherwise, we'll
+        # use the found faces (and the provided path if any are missing...)
+        face_data = list(self._load_all_image_data(face_image_paths, self.filepath))
+        face_widths, face_heights, face_data = zip(*face_data)
+
+        # All widths and heights must be the same... so, if needed, scale the stupid images.
+        width, height, face_data = self._scale_images(face_widths, face_heights, face_data)
+
+        # Now generate the stoopid cube map
+        image_name = Path(self.filepath).name
+        idx = image_name.rfind('_')
+        if idx != -1:
+            suffix = image_name[idx+1:idx+3]
+            if suffix in _CUBE_FACES.values():
+                image_name = image_name[:idx] + image_name[idx+3:]
+        cubemap_image = self._generate_cube_map(image_name, width, height, face_data)
+
+        # If a texture was provided, we can assign this generated cube map to it...
+        if self.texture_name:
+            texture = bpy.data.textures[self.texture_name]
+            texture.environment_map.source = "IMAGE_FILE"
+            texture.image = cubemap_image
+
+        self._report.progress_end()
+        return {"FINISHED"}
+
+    def _find_cube_files(self, filepath):
+        self._report.progress_advance()
+        self._report.progress_range = len(BLENDER_CUBE_MAP)
+        self._report.msg("Searching for cubemap faces...")
+
+        idx = filepath.rfind('_')
+        if idx != -1:
+            files = []
+            for key in BLENDER_CUBE_MAP:
+                suffix = _CUBE_FACES[key]
+                face_path = filepath[:idx+1] + suffix + filepath[idx+3:]
+                face_name = key[:-4].upper()
+                if Path(face_path).is_file():
+                    self._report.msg("Found face '{}': {}", face_name, face_path, indent=1)
+                    files.append(face_path)
+                else:
+                    self._report.warn("Using default face data for face '{}'", face_name, indent=1)
+                    files.append(None)
+                self._report.progress_increment()
+            return tuple(files)
+
+    def _generate_cube_map(self, req_name, face_width, face_height, face_data):
+        self._report.progress_advance()
+        self._report.msg("Generating cubemap image...")
+
+        # If a texture was provided, we should check to see if as have an image we can replace...
+        image = bpy.data.textures[self.texture_name].image if self.texture_name else None
+
+        # Init our image
+        image_width = face_width * 3
+        image_height = face_height * 2
+        if image is not None and self.overwrite_existing:
+            image.source = "GENERATED"
+            image.generated_width = image_width
+            image.generated_height = image_height
+        else:
+            image = bpy.data.images.new(req_name, image_width, image_height, True)
+        image_datasz = image_width * image_height * 4
+        image_data = bytearray(image_datasz)
+        face_num = len(BLENDER_CUBE_MAP)
+
+        # This is the inverse of the operation found in MaterialConverter._finalize_cube_map
+        for i in range(face_num):
+            col_id = i if i < 3 else i - 3
+            row_start = 0 if i < 3 else face_height
+            row_end = face_height if i < 3 else image_height
+
+            # TIL: Blender's coordinate system has its origin in the lower left, while Plasma's
+            # is in the upper right. We could do some fancy flipping stuff, but there are already
+            # mitigations in code for that. So, we disabled the GLTexture's flipping helper and
+            # will just swap the locations of the images in the list. le wout.
+            j = i + 3 if i < 3 else i - 3
+            for row_current in range(row_start, row_end, 1):
+                src_start_idx = (row_current - row_start) * face_width * 4
+                src_end_idx = src_start_idx + (face_width * 4)
+                dst_start_idx = (row_current * image_width * 4) + (col_id * face_width * 4)
+                dst_end_idx = dst_start_idx + (face_width * 4)
+                image_data[dst_start_idx:dst_end_idx] = face_data[j][src_start_idx:src_end_idx]
+
+        # FFFUUUUU... Blender wants a list of floats
+        pixels = [None] * image_datasz
+        for i in range(image_datasz):
+            pixels[i] = image_data[i] / 255
+
+        # Obligatory remark: "Blender sucks"
+        image.pixels = pixels
+        image.update()
+        image.pack(True)
+        return image
+
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    def _load_all_image_data(self, face_image_paths, default_image_path):
+        self._report.progress_advance()
+        self._report.progress_range = len(BLENDER_CUBE_MAP)
+        self._report.msg("Loading cubemap faces...")
+
+        default_data = None
+        for image_path in face_image_paths:
+            if image_path is None:
+                if default_data is None:
+                    default_data = self._load_single_image_data(default_image_path)
+                yield default_data
+            else:
+                yield self._load_single_image_data(image_path)
+            self._report.progress_increment()
+
+    def _load_single_image_data(self, filepath):
+        images = bpy.data.images
+        with TemporaryObject(images.load(filepath), images.remove) as blimage:
+            with GLTexture(image=blimage, fast=True) as glimage:
+                return glimage.image_data
+
+    def _scale_images(self, face_widths, face_heights, face_data):
+        self._report.progress_advance()
+        self._report.progress_range = len(BLENDER_CUBE_MAP)
+        self._report.msg("Checking cubemap face dimensions...")
+
+        # Take the smallest face width and get its POT variety (so we don't rescale on export)
+        min_width = ensure_power_of_two(min(face_widths))
+        min_height = ensure_power_of_two(min(face_heights))
+
+        # They're called CUBEmaps, dingus...
+        if self.require_cube:
+            dimension = min(min_width, min_height)
+            min_width, min_height = dimension, dimension
+
+        # Insert grumbling here about tuples being immutable...
+        result_data = list(face_data)
+
+        for i in range(len(BLENDER_CUBE_MAP)):
+            face_width, face_height = face_widths[i], face_heights[i]
+            if face_width != min_width or face_height != min_height:
+                face_name = BLENDER_CUBE_MAP[i][:-4].upper()
+                self._report.msg("Resizing face '{}' from {}x{} to {}x{}", face_name,
+                                 face_width, face_height, min_width, min_height,
+                                 indent=1)
+                result_data[i] = scale_image(face_data[i], face_width, face_height,
+                                                         min_width, min_height)
+            self._report.progress_increment()
+        return min_width, min_height, tuple(result_data)

--- a/korman/operators/op_toolbox.py
+++ b/korman/operators/op_toolbox.py
@@ -102,6 +102,25 @@ class PlasmaToggleAllPlasmaObjectsOperator(ToolboxOperator, bpy.types.Operator):
         return {"FINISHED"}
 
 
+class PlasmaToggleEnvironmentMapsOperator(ToolboxOperator, bpy.types.Operator):
+    bl_idname = "texture.plasma_toggle_environment_maps"
+    bl_label = "Toggle Environment Maps"
+    bl_description = "Changes the state of all Environment Maps"
+
+    enable = BoolProperty(name="Enable", description="Enable Environment Maps")
+
+    def execute(self, context):
+        enable = self.enable
+        for material in bpy.data.materials:
+            for slot in material.texture_slots:
+                if slot is None:
+                    continue
+                if slot.texture.type == "ENVIRONMENT_MAP":
+                    slot.use = enable
+        return {"FINISHED"}
+
+
+
 class PlasmaTogglePlasmaObjectsOperator(ToolboxOperator, bpy.types.Operator):
     bl_idname = "object.plasma_toggle_selected_objects"
     bl_label = "Toggle Plasma Objects"

--- a/korman/ui/ui_texture.py
+++ b/korman/ui/ui_texture.py
@@ -37,18 +37,25 @@ class PlasmaEnvMapPanel(TextureButtonsPanel, bpy.types.Panel):
         return False
 
     def draw(self, context):
-        layer_props = context.texture.plasma_layer
+        texture = context.texture
+        layer_props, envmap = texture.plasma_layer, texture.environment_map
         layout = self.layout
 
-        layout.prop(layer_props, "envmap_color")
-        layout.separator()
+        if envmap.source in {"ANIMATED", "STATIC"}:
+            layout.prop(layer_props, "envmap_color")
+            layout.separator()
 
-        layout.label("Visibility Sets:")
-        ui_list.draw_list(layout, "VisRegionListUI", "texture", layer_props,
-                          "vis_regions", "active_region_index", rows=2, maxrows=3)
-        rgns = layer_props.vis_regions
-        if layer_props.vis_regions:
-            layout.prop(rgns[layer_props.active_region_index], "control_region")
+            layout.label("Visibility Sets:")
+            ui_list.draw_list(layout, "VisRegionListUI", "texture", layer_props,
+                              "vis_regions", "active_region_index", rows=2, maxrows=3)
+            rgns = layer_props.vis_regions
+            if layer_props.vis_regions:
+                layout.prop(rgns[layer_props.active_region_index], "control_region")
+        elif envmap.source == "IMAGE_FILE":
+            op = layout.operator("image.plasma_build_cube_map",
+                                 text="Build Cubemap from Cube Faces",
+                                 icon="MATCUBE")
+            op.texture_name = context.texture.name
 
 
 class PlasmaLayerPanel(TextureButtonsPanel, bpy.types.Panel):

--- a/korman/ui/ui_toolbox.py
+++ b/korman/ui/ui_toolbox.py
@@ -41,7 +41,11 @@ class PlasmaToolboxPanel(ToolboxPanel, bpy.types.Panel):
         disable_all = col.operator("object.plasma_toggle_all_objects", icon="OBJECT_DATA", text="Disable All")
         disable_all.enable = False
 
+        col.label("Textures:")
+        col.operator("texture.plasma_enable_all_textures", icon="TEXTURE", text="Enable All")
+        col.operator("texture.plasma_toggle_environment_maps", icon="IMAGE_RGB", text="Enable All EnvMaps").enable = True
+        col.operator("texture.plasma_toggle_environment_maps", icon="IMAGE_RGB_ALPHA", text="Disable All EnvMaps").enable = False
+
         col.label("Convert:")
         col.operator("object.plasma_convert_plasma_objects", icon="OBJECT_DATA", text="Plasma Objects")
-        col.operator("texture.plasma_enable_all_textures", icon="TEXTURE")
         col.operator("texture.plasma_convert_layer_opacities", icon="IMAGE_RGB_ALPHA", text="Layer Opacities")

--- a/korman/ui/ui_world.py
+++ b/korman/ui/ui_world.py
@@ -143,6 +143,7 @@ class PlasmaAgePanel(AgeButtonsPanel, bpy.types.Panel):
         col.prop(age, "use_texture_page")
 
         layout.separator()
+        layout.prop(age, "envmap_method")
         layout.prop(age, "lighting_method")
         layout.prop(age, "texcache_method")
 


### PR DESCRIPTION
This changeset allows the artist to control how Korman exports dynamic environment maps at export time due to their ability to cause ages to slow down. One specific concern was that Dynamic Camera Maps were being silently downgraded to Dynamic Environment Maps (from 1 face to 6 faces) when exporting to Path of the Shell.

Also included is the ability to export cube maps as `plCubicEnvironmap` objects. Korman will take a Blender cube map (six faces in one image) and split it into six different face images. This nesecitated a rather large rewrite of the image data handling code. We now do all of the mipmapping on the CPU in Korman code as a result. This is both a good and bad thing in that 1) we are no longer reliant on a deprecated OpenGL feature, 2) the pure Python image scaling code is slower than molasses running uphill in Siberia. Don't use the reference implementation of korlib, m'kay?

To facilitate easier creation of cube maps, when the environment map texture type is `IMAGE_FILE`, the Plasma Environment Map panel offers an operator that takes the output of the Plasma console command `Graphics.Renderer.GrabCubeMap` and generates a cubemap from it. It can also accept any arbitrary image and will generate a cubemap with six identical faces.

Closes #71