### PR TITLE
Fix #132

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -255,10 +255,8 @@ class MaterialConverter:
             hsgmat.addLayer(layer.key)
 
         # Cache this material for later
-        if bo in self._obj2mat:
-            self._obj2mat[bo].append(hsgmat.key)
-        else:
-            self._obj2mat[bo] = [hsgmat.key]
+        mat_list = self._obj2mat.setdefault(bo, [])
+        mat_list.append(hsgmat.key)
 
         # Looks like we're done...
         return hsgmat.key

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -184,7 +184,7 @@ class MaterialConverter:
         # that's a special case as of the writing of this code.
         single_user = self._requires_single_user_material(bo, bm)
         if single_user:
-            mat_name = "{}_{}".format(bo.name, bm.name)
+            mat_name = "{}_AutoSingle".format(bm.name) if bo.name == bm.name else "{}_{}".format(bo.name, bm.name)
             self._report.msg("Exporting Material '{}' as single user '{}'", bm.name, mat_name, indent=1)
             hgmat = None
         else:


### PR DESCRIPTION
This should fix #132 and some other issues I observed when looking through the code.

Previously, we unconditionally exported materials. This worked in the situation that every material was single user. Now, the code should not assume that materials are single user and search for existing objects before creating them. If an object is lightmapped, Korman will now force it to have its own material. If you're sharing a non-lightmapped material, a lot of the material exporter code is now skipped. There is a bit of inefficiency when materials are shared among lightmapped objects in that the same layers will be converted multiple times. This is mostly just a time waster though and not an actual problem.