### PR TITLE
Make node trees reusable.

### DIFF
--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -38,8 +38,8 @@ class Exporter:
         self._op = op # Blender export operator
         self._objects = []
         self.actors = set()
-        self.node_trees_exported = set()
         self.want_node_trees = {}
+        self.exported_nodes = {}
 
     def run(self):
         log = logger.ExportVerboseLogger if self._op.verbose else logger.ExportProgressLogger
@@ -276,13 +276,11 @@ class Exporter:
         inc_progress = self.report.progress_increment
 
         self.report.msg("\nChecking Logic Trees...")
-        need_to_export = [(name, bo, so) for name, (bo, so) in self.want_node_trees.items()
-                                         if name not in self.node_trees_exported]
-        self.report.progress_value = len(self.want_node_trees) - len(need_to_export)
-
-        for tree, bo, so in need_to_export:
-            self.report.msg("NodeTree '{}'", tree, indent=1)
-            bpy.data.node_groups[tree].export(self, bo, so)
+        for tree_name, references in self.want_node_trees.items():
+            self.report.msg("NodeTree '{}'", tree_name, indent=1)
+            tree = bpy.data.node_groups[tree_name]
+            for bo, so in references:
+                tree.export(self, bo, so)
             inc_progress()
 
     def _harvest_actors(self):

--- a/korman/nodes/node_avatar.py
+++ b/korman/nodes/node_avatar.py
@@ -56,10 +56,10 @@ class PlasmaSittingBehaviorNode(PlasmaNodeBase, bpy.types.Node):
         layout.prop_menu_enum(self, "approach")
 
     def get_key(self, exporter, so):
-        return exporter.mgr.find_create_key(plSittingModifier, name=self.key_name, so=so)
+        return self._find_create_key(plSittingModifier, exporter, so=so)
 
     def export(self, exporter, bo, so):
-        sitmod = self.get_key(exporter, so).object
+        sitmod = self._find_create_object(plSittingModifier, exporter, so=so)
         for flag in self.approach:
             sitmod.miscFlags |= getattr(plSittingModifier, flag)
         for i in self.find_outputs("satisfies"):

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -82,7 +82,7 @@ class PlasmaExcludeRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.typ
     def get_key(self, exporter, parent_so):
         if self.region_object is None:
             self.raise_error("Region must be set")
-        return exporter.mgr.find_create_key(plExcludeRegionModifier, bl=self.region_object, name=self.key_name)
+        return self._find_create_key(plExcludeRegionModifier, exporter, bl=self.region_object)
 
     def harvest_actors(self, bo):
         return [i.safepoint.name for i in self.find_input_sockets("safe_points") if i.safepoint is not None]
@@ -107,6 +107,10 @@ class PlasmaExcludeRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.typ
         if exporter.mgr.getVer() < pvMoul:
             physical.memberGroup = plSimDefs.kGroupDetector
             physical.collideGroup |= 1 << plSimDefs.kGroupDynamic
+
+    @property
+    def export_once(self):
+        return True
 
     @classmethod
     def _idprop_mapping(cls):

--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -544,6 +544,8 @@ class PlasmaOneShotMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacks
         layout.prop(self, "seek")
 
     def export(self, exporter, bo, so):
+        # Note: we purposefully allow this to proceed because plOneShotMod is a MultiMod, so we
+        # want all referencing SOs to get a copy of the modifier.
         oneshotmod = self.get_key(exporter, so).object
         oneshotmod.animName = self.animation
         oneshotmod.drivable = self.drivable
@@ -553,12 +555,11 @@ class PlasmaOneShotMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacks
         oneshotmod.seekDuration = 1.0
 
     def get_key(self, exporter, so):
-        name = self.key_name
         if self.pos_object is not None:
             pos_so = exporter.mgr.find_create_object(plSceneObject, bl=self.pos_object)
-            return exporter.mgr.find_create_key(plOneShotMod, name=name, so=pos_so)
+            return self._find_create_key(plOneShotMod, exporter, so=pos_so)
         else:
-            return exporter.mgr.find_create_key(plOneShotMod, name=name, so=so)
+            return self._find_create_key(plOneShotMod, exporter, so=so)
 
     def harvest_actors(self, bo):
         actors = set()

--- a/korman/nodes/node_python.py
+++ b/korman/nodes/node_python.py
@@ -252,10 +252,15 @@ class PlasmaPythonFileNode(PlasmaVersionedNode, bpy.types.Node):
             layout.label(text="Script '{}' is not loaded in Blender".format(self.filename), icon="ERROR")
 
     def get_key(self, exporter, so):
-        return exporter.mgr.find_create_key(plPythonFileMod, name=self.key_name, so=so)
+        return self._find_create_key(plPythonFileMod, exporter, so=so)
 
     def export(self, exporter, bo, so):
         pfm = self.get_key(exporter, so).object
+
+        # No need to continue if the PFM was already generated.
+        if self.previously_exported(exporter):
+            return
+
         py_name = Path(self.filename).stem
         pfm.filename = py_name
 

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -83,7 +83,7 @@ class PlasmaResponderNode(PlasmaVersionedNode, bpy.types.Node):
         layout.prop(self, "no_ff_sounds")
 
     def get_key(self, exporter, so):
-        return exporter.mgr.find_create_key(plResponderModifier, name=self.key_name, so=so)
+        return self._find_create_key(plResponderModifier, exporter, so=so)
 
     def export(self, exporter, bo, so):
         responder = self.get_key(exporter, so).object
@@ -134,6 +134,11 @@ class PlasmaResponderNode(PlasmaVersionedNode, bpy.types.Node):
         for stateNode in self.find_outputs("state_refs", "PlasmaResponderStateNode"):
             stateMgr.register_state(stateNode)
         stateMgr.convert_states(exporter, so)
+
+    @property
+    def export_once(self):
+        # What exactly is a reused responder? All the messages are directed, after all...
+        return True
 
     @property
     def latest_version(self):

--- a/korman/nodes/node_softvolume.py
+++ b/korman/nodes/node_softvolume.py
@@ -130,7 +130,7 @@ class PlasmaSoftVolumeInvertNode(PlasmaNodeBase, bpy.types.Node):
     ])
 
     def get_key(self, exporter, so):
-        return exporter.mgr.find_create_key(plSoftVolumeInvert, name=self.key_name, so=so)
+        return self._find_create_key(plSoftVolumeInvert, exporter, so=so)
 
     def export(self, exporter, bo, so):
         parent = self.find_input("input")
@@ -146,6 +146,10 @@ class PlasmaSoftVolumeInvertNode(PlasmaNodeBase, bpy.types.Node):
         else:
             sv.insideStrength = 1.0
             sv.outsideStrength = 0.0
+
+    @property
+    def export_once(self):
+        return True
 
 
 class PlasmaSoftVolumeLinkNode(PlasmaNodeBase):
@@ -180,6 +184,10 @@ class PlasmaSoftVolumeLinkNode(PlasmaNodeBase):
             sv.insideStrength = 1.0
             sv.outsideStrength = 0.0
 
+    @property
+    def export_once(self):
+        return True
+
 
 class PlasmaSoftVolumeIntersectNode(PlasmaSoftVolumeLinkNode, bpy.types.Node):
     bl_category = "SV"
@@ -188,7 +196,7 @@ class PlasmaSoftVolumeIntersectNode(PlasmaSoftVolumeLinkNode, bpy.types.Node):
 
     def get_key(self, exporter, so):
         ## FIXME: SoftVolumeIntersect should not be listed as an interface
-        return exporter.mgr.find_create_key(plSoftVolumeIntersect, name=self.key_name, so=so)
+        return self._find_create_key(plSoftVolumeIntersect, exporter, so=so)
 
 
 class PlasmaSoftVolumeUnionNode(PlasmaSoftVolumeLinkNode, bpy.types.Node):
@@ -198,4 +206,4 @@ class PlasmaSoftVolumeUnionNode(PlasmaSoftVolumeLinkNode, bpy.types.Node):
 
     def get_key(self, exporter, so):
         ## FIXME: SoftVolumeUnion should not be listed as an interface
-        return exporter.mgr.find_create_key(plSoftVolumeUnion, name=self.key_name, so=so)
+        return self._find_create_key(plSoftVolumeUnion, exporter, so=so)

--- a/korman/properties/modifiers/region.py
+++ b/korman/properties/modifiers/region.py
@@ -284,9 +284,8 @@ class PlasmaSoftVolume(idprops.IDPropMixin, PlasmaModifierProperties):
 
     def _export_sv_nodes(self, exporter, bo, so):
         tree = self.get_node_tree()
-        if tree.name not in exporter.node_trees_exported:
-            exporter.node_trees_exported.add(tree.name)
-            tree.export(exporter, bo, so)
+        # Stash for later
+        exporter.want_node_trees.setdefault(tree.name, set()).add((bo, so))
 
     def get_node_tree(self):
         if self.node_tree is None:

--- a/korman/ui/modifiers/logic.py
+++ b/korman/ui/modifiers/logic.py
@@ -19,25 +19,22 @@ from .. import ui_list
 
 class LogicListUI(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_property, index=0, flt_flag=0):
-        layout.prop(item, "name", emboss=False, text="", icon="NODETREE")
+        if item.node_tree:
+            # Using layout.prop on the pointer prevents clicking on the item O.o
+            layout.label(item.node_tree.name, icon="NODETREE")
+        else:
+            layout.label("[Empty]")
 
 
 def advanced_logic(modifier, layout, context):
     ui_list.draw_modifier_list(layout, "LogicListUI", modifier, "logic_groups",
-                               "active_group_index", name_prefix="Logic",
-                               name_prop="name", rows=2, maxrows=3)
+                               "active_group_index", rows=2, maxrows=3)
 
     # Modify the logic groups
     if modifier.logic_groups:
         logic = modifier.logic_groups[modifier.active_group_index]
         layout.row().prop_menu_enum(logic, "version")
         layout.prop(logic, "node_tree", icon="NODETREE")
-        try:
-            layout.prop_search(logic, "node_name", logic.node_tree, "nodes", icon="NODE")
-        except:
-            row = layout.row()
-            row.enabled = False
-            row.prop(logic, "node_name", icon="NODE")
 
 def spawnpoint(modifier, layout, context):
     layout.label(text="Avatar faces negative Y.")


### PR DESCRIPTION
Previously, reusing node trees required careful thought and specification of specific nodes in the advanced logic modifier. This tedious requirement has been removed in favor of ensuring that the nodes themselves take into account whether or not they should generate and attach plasma objects.