### PR TITLE
Add Blend Texture Exporter

### DIFF
--- a/korman/exporter/explosions.py
+++ b/korman/exporter/explosions.py
@@ -32,6 +32,11 @@ class ExportError(Exception):
             super(Exception, self).__init__(args[0])
 
 
+class BlendNotSupported(ExportError):
+    def __init__(self, progression, axis):
+        super(ExportError, self).__init__("Alpha Blend not supported: {}, {}", progression, axis)
+
+
 class BlenderOptionNotSupportedError(ExportError):
     def __init__(self, opt):
         super(ExportError, self).__init__("Unsupported Blender Option: '{}'".format(opt))

--- a/korman/ui/ui_texture.py
+++ b/korman/ui/ui_texture.py
@@ -93,14 +93,15 @@ class PlasmaLayerPanel(TextureButtonsPanel, bpy.types.Panel):
 
         split = layout.split()
         col = split.column()
-        col.active = texture.use_mipmap
+        detail_map_candidate = texture.type == "IMAGE" and texture.use_mipmap
+        col.active = detail_map_candidate
         col.prop(layer_props, "is_detail_map", text="Detail Blending")
         col = col.column(align=True)
-        col.active = texture.use_mipmap and layer_props.is_detail_map
+        col.active = detail_map_candidate and layer_props.is_detail_map
         col.prop(layer_props, "detail_fade_start")
         col.prop(layer_props, "detail_fade_stop")
         col = split.column(align=True)
-        col.active = texture.use_mipmap and layer_props.is_detail_map
+        col.active = detail_map_candidate and layer_props.is_detail_map
         col.label(text="")
         col.prop(layer_props, "detail_opacity_start")
         col.prop(layer_props, "detail_opacity_stop")


### PR DESCRIPTION
This adds support for the BlendTexture type to the material exporter. This has been done in preparation for #155, which will need alpha blend layers to be generated for certain footprint materials. The math was, in some cases, lifted from PyPRP.