### PR TITLE
Decal Modifier

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -405,6 +405,10 @@ class MaterialConverter:
             if layer_props.skip_depth_write:
                 state.ZFlags |= hsGMatState.kZNoZWrite
 
+            if bo.plasma_modifiers.decal_material.enabled:
+                hsgmat.compFlags |= hsGMaterial.kCompDecal
+                state.ZFlags |= hsGMatState.kZIncLayer | hsGMatState.kZNoZWrite
+
         # Export the specific texture type
         self._tex_exporters[texture.type](bo, layer, slot)
 
@@ -1137,6 +1141,8 @@ class MaterialConverter:
         if modifiers.lightmap.bake_lightmap:
             return True
         if modifiers.water_basic.enabled:
+            return True
+        if modifiers.decal_material.enabled:
             return True
         return False
 

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -564,3 +564,15 @@ class PlasmaVisibilitySet(PlasmaModifierProperties):
             if not region.control_region:
                 raise ExportError("{}: Not all Visibility Controls are set up properly in Visibility Set".format(bo.name))
             addRegion(exporter.mgr.find_create_key(plVisRegion, bl=region.control_region))
+
+
+class PlasmaDecalMod(PlasmaModifierProperties):
+    pl_id = "decal_material"
+
+    bl_category = "Render"
+    bl_label = "Decal Object"
+    bl_description = "Exports this object as a decal to its parent"
+
+    def export(self, exporter, bo, so):
+        if not bo.parent:
+            raise ExportError("{}: Decal object must have a parent".format(bo.name))


### PR DESCRIPTION
Alternate implementation of #84 using modifiers.

Decals require 3 things:
* Co-incident geometry that is parented to the main mesh
* A material with the CompDecal flag
* Layers with ZIncLayer and NoZWrite

This adds a modifier that will enforce at export time that the object has a parent, that the material is not shared with any other objects, and that the material and layer have the correct flags.