### PR TITLE
Image Operator Menu

### DIFF
--- a/korman/operators/op_image.py
+++ b/korman/operators/op_image.py
@@ -127,15 +127,8 @@ class PlasmaBuildCubeMapOperator(bpy.types.Operator):
                                   default="",
                                   options={"HIDDEN"})
 
-    def __init__(self):
-        self._report = ExportProgressLogger()
-        self._report.progress_add_step("Finding Face Images")
-        self._report.progress_add_step("Loading Face Images")
-        self._report.progress_add_step("Scaling Face Images")
-        self._report.progress_add_step("Generating Cube Map")
-
     def execute(self, context):
-        with ConsoleToggler(True) as _:
+        with ConsoleToggler(True), ExportProgressLogger() as self._report:
             try:
                 self._execute()
             except ExportError as error:
@@ -145,6 +138,10 @@ class PlasmaBuildCubeMapOperator(bpy.types.Operator):
                 return {"FINISHED"}
 
     def _execute(self):
+        self._report.progress_add_step("Finding Face Images")
+        self._report.progress_add_step("Loading Face Images")
+        self._report.progress_add_step("Scaling Face Images")
+        self._report.progress_add_step("Generating Cube Map")
         self._report.progress_start("BUILDING CUBE MAP")
         if not Path(self.filepath).is_file():
             raise ExportError("No cube image found at '{}'".format(self.filepath))

--- a/korman/ui/ui_menus.py
+++ b/korman/ui/ui_menus.py
@@ -13,7 +13,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
 
-from ..operators.op_mesh import *
+import bpy
+import functools
 
 class PlasmaMenu:
     @classmethod
@@ -32,14 +33,30 @@ class PlasmaAddMenu(PlasmaMenu, bpy.types.Menu):
         layout.operator("mesh.plasma_ladder_add", text="Ladder", icon="COLLAPSEMENU")
 
 
-def build_plasma_menu(self, context):
+class PlasmaImageMenu(PlasmaMenu, bpy.types.Menu):
+    bl_idname = "menu.plasma_image"
+    bl_label = "Plasma"
+    bl_description = "Plasma Image Operators"
+
+    def draw(self, context):
+        layout = self.layout
+
+        layout.operator("image.plasma_bake_image_alpha", icon="IMAGE_RGB_ALPHA")
+
+
+def _build_plasma_menu(menu_operator, self, context):
     if context.scene.render.engine != "PLASMA_GAME":
         return
     self.layout.separator()
-    self.layout.menu("menu.plasma_add", icon="URL")
+    self.layout.menu(menu_operator, icon="URL")
+
+build_plasma_add_menu = functools.partial(_build_plasma_menu, "menu.plasma_add")
+build_plasma_image_menu = functools.partial(_build_plasma_menu, "menu.plasma_image")
 
 def register():
-    bpy.types.INFO_MT_add.append(build_plasma_menu)
+    bpy.types.INFO_MT_add.append(build_plasma_add_menu)
+    bpy.types.IMAGE_MT_image.append(build_plasma_image_menu)
 
 def unregister():
-    bpy.types.INFO_MT_add.remove(build_plasma_menu)
+    bpy.types.INFO_MT_add.remove(build_plasma_add_menu)
+    bpy.types.IMAGE_MT_image.remove(build_plasma_image_menu)

--- a/korman/ui/ui_menus.py
+++ b/korman/ui/ui_menus.py
@@ -42,6 +42,7 @@ class PlasmaImageMenu(PlasmaMenu, bpy.types.Menu):
         layout = self.layout
 
         layout.operator("image.plasma_bake_image_alpha", icon="IMAGE_RGB_ALPHA")
+        layout.operator("image.plasma_build_cube_map", icon="MATCUBE")
 
 
 def _build_plasma_menu(menu_operator, self, context):

--- a/korman/ui/ui_menus.py
+++ b/korman/ui/ui_menus.py
@@ -42,6 +42,8 @@ class PlasmaImageMenu(PlasmaMenu, bpy.types.Menu):
         layout = self.layout
 
         layout.operator("image.plasma_bake_image_alpha", icon="IMAGE_RGB_ALPHA")
+        layout.operator("image.plasma_clamp_image_alpha", icon="IMAGE_ALPHA")
+        layout.separator()
         layout.operator("image.plasma_build_cube_map", icon="MATCUBE")
 
 


### PR DESCRIPTION
Adds some hopefully useful operators for baking alpha to an image and clamping an image to on/off alpha (for forcing DXT1 export). Also fixes an issue with the cube map operator where the progress meter could run forever in the case of an error.