### PR TITLE
Add Linking Book guide.

### DIFF
--- a/korman/exporter/utils.py
+++ b/korman/exporter/utils.py
@@ -71,3 +71,24 @@ def bmesh_temporary_object(name : str, factory : Callable, page_name : str=None)
     finally:
         bm.free()
         bpy.context.scene.objects.unlink(obj)
+
+@contextmanager
+def bmesh_object(name : str):
+    """Creates an object and mesh that will be removed if the context is exited
+       due to an error"""
+    mesh = bpy.data.meshes.new(name)
+    obj = bpy.data.objects.new(name, mesh)
+    obj.draw_type = "WIRE"
+    bpy.context.scene.objects.link(obj)
+
+    bm = bmesh.new()
+    try:
+        yield obj, bm
+    except:
+        bpy.context.scene.objects.unlink(obj)
+        bpy.data.meshes.remove(mesh)
+        raise
+    else:
+        bm.to_mesh(mesh)
+    finally:
+        bm.free()

--- a/korman/operators/op_mesh.py
+++ b/korman/operators/op_mesh.py
@@ -140,11 +140,9 @@ class PlasmaAddLadderMeshOperator(PlasmaMeshOperator, bpy.types.Operator):
             row.label("Warning: Operator does not work in local view mode", icon="ERROR")
 
     def execute(self, context):
-        if context.mode == "OBJECT":
-            self.create_ladder_objects()
-        else:
-            self.report({"WARNING"}, "Ladder creation only valid in Object mode")
-            return {"CANCELLED"}
+        if context.space_data.local_view:
+            bpy.ops.view3d.localview()
+        self.create_ladder_objects()
         return {"FINISHED"}
 
     def create_guide_rungs(self):
@@ -431,13 +429,10 @@ class PlasmaAddLinkingBookMeshOperator(PlasmaMeshOperator, bpy.types.Operator):
             row.label("Warning: Operator does not work in local view mode", icon="ERROR")
 
     def execute(self, context):
-        if context.mode == "OBJECT":
-            self.create_linkingbook_objects()
-        else:
-            self.report({"WARNING"}, "Linking Book creation only valid in Object mode")
-            return {"CANCELLED"}
+        if context.space_data.local_view:
+            bpy.ops.view3d.localview()
+        self.create_linkingbook_objects()
         return {"FINISHED"}
-
 
     def create_linkingbook_objects(self):
         bpyscene = bpy.context.scene

--- a/korman/ui/ui_menus.py
+++ b/korman/ui/ui_menus.py
@@ -30,6 +30,7 @@ class PlasmaAddMenu(PlasmaMenu, bpy.types.Menu):
         layout = self.layout
 
         layout.operator("mesh.plasma_ladder_add", text="Ladder", icon="COLLAPSEMENU")
+        layout.operator("mesh.plasma_linkingbook_add", text="Linking Book", icon="FILE_IMAGE")
 
 
 def build_plasma_menu(self, context):


### PR DESCRIPTION
This adds a new item to the `Add...Plasma...` menu which creates a set of pre-configured Linking Book objects.  It creates a guide the artist can line up with the linking panel on a linking book, along with a seek point and clickable region parented to the panel guide, as well as an enabled Linking Book modifier.  The seek point is placed at a pre-computed position so that it lines up with the linking panel guide properly for both the standing and kneeling Link Animations.