### PR TITLE
Add premade Lamp Flare.

### DIFF
--- a/korman/ui/ui_menus.py
+++ b/korman/ui/ui_menus.py
@@ -29,6 +29,7 @@ class PlasmaAddMenu(PlasmaMenu, bpy.types.Menu):
     def draw(self, context):
         layout = self.layout
 
+        layout.operator("mesh.plasma_flare_add", text="Lamp Flare", icon="PARTICLES")
         layout.operator("mesh.plasma_ladder_add", text="Ladder", icon="COLLAPSEMENU")
         layout.operator("mesh.plasma_linkingbook_add", text="Linking Book", icon="FILE_IMAGE")
 


### PR DESCRIPTION
This adds a new item to the `Add...Plasma...` menu which provides a pre-configured lamp flare.  

It creates a set of objects for an optimal, general-purpose glow around most lamps:
- An empty with a Swivel modifier at the chosen location (usually the lamp).
- A plane parented to the empty for the flare texture, with an Opacity Fade modifier which uses the plane's center for Line-of-Sight.
