### PR TITLE
Font Export

### DIFF
--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -273,18 +273,9 @@ class Exporter:
             self.report.msg("No material(s) on the ObData, so no drawables", indent=1)
 
     def _export_font_blobj(self, so, bo):
-        self.report.msg("Converting font to mesh for export")
-        bpy.ops.object.select_all(action='DESELECT')
-        bpy.context.scene.objects.active = bo
-        bo.select = True
-        convertible = bpy.ops.object.convert.poll()
-        if convertible:
-            bpy.ops.object.convert(target='MESH', keep_original= True)
-            convertedFont = bpy.context.active_object
-            self._export_mesh_blobj(so, convertedFont)
-            bpy.ops.object.delete()
-        else:
-            self.report.msg("not convertible, skipping...")
+        self.animation.convert_object_animations(bo, so)
+        with utils.temporary_mesh_object(bo) as meshObj:
+            self._export_mesh_blobj(so, meshObj)
 
     def _export_referenced_node_trees(self):
         self.report.progress_advance()

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -272,6 +272,20 @@ class Exporter:
         else:
             self.report.msg("No material(s) on the ObData, so no drawables", indent=1)
 
+    def _export_font_blobj(self, so, bo):
+        self.report.msg("Converting font to mesh for export")
+        bpy.ops.object.select_all(action='DESELECT')
+        bpy.context.scene.objects.active = bo
+        bo.select = True
+        convertible = bpy.ops.object.convert.poll()
+        if convertible:
+            bpy.ops.object.convert(target='MESH', keep_original= True)
+            convertedFont = bpy.context.active_object
+            self._export_mesh_blobj(so, convertedFont)
+            bpy.ops.object.delete()
+        else:
+            self.report.msg("not convertible, skipping...")
+
     def _export_referenced_node_trees(self):
         self.report.progress_advance()
         self.report.progress_range = len(self.want_node_trees)

--- a/korman/exporter/utils.py
+++ b/korman/exporter/utils.py
@@ -92,3 +92,20 @@ def bmesh_object(name : str):
         bm.to_mesh(mesh)
     finally:
         bm.free()
+
+@contextmanager
+def temporary_mesh_object(source : bpy.types.Object) -> bpy.types.Object:
+    """Creates a temporary mesh object from a nonmesh object that will only exist for the duration
+       of the context."""
+    assert source.type != "MESH"
+
+    obj = bpy.data.objects.new(source.name, source.to_mesh(bpy.context.scene, True, "RENDER"))
+    obj.draw_type = "WIRE"
+    obj.matrix_basis, obj.matrix_world = source.matrix_basis, source.matrix_world
+    obj.parent = source.parent
+
+    bpy.context.scene.objects.link(obj)
+    try:
+        yield obj
+    finally:
+        bpy.data.objects.remove(obj)


### PR DESCRIPTION
Added export / conversion function for turning font objects into mesh objects that can be exported to Plasma.

Since I'm using so many font objects, I found myself wanting Korman to just automatically export them, instead of manually converting and managing a bunch of mesh copies. Thought I would take a crack at it, and managed to get it working.

Uses operators (discouraged practice, I know, but I couldn't figure out how to do it using low level functions after spending more time than I wanted looking through old Blender Python API documentation)

Deselects everything, selects the current blender object, converts it, then hands it over to the mesh export function, keeps the original and cleans up by deleting the converted mesh after export.