### PR TITLE
Add Double Sided Toolbox Operators

### DIFF
--- a/korman/operators/op_toolbox.py
+++ b/korman/operators/op_toolbox.py
@@ -171,6 +171,37 @@ class PlasmaToggleAllPlasmaObjectsOperator(ToolboxOperator, bpy.types.Operator):
             i.plasma_object.enabled = self.enable
         return {"FINISHED"}
 
+        
+class PlasmaToggleDoubleSidedOperator(ToolboxOperator, bpy.types.Operator):
+    bl_idname = "mesh.plasma_toggle_double_sided"
+    bl_label = "Toggle All Double Sided"
+    bl_description = "Toggles all meshes to be double sided"
+    
+    enable = BoolProperty(name="Enable", description="Enable Double Sided")
+    
+    def execute(self, context):
+        enable = self.enable
+        for mesh in bpy.data.meshes:
+            mesh.show_double_sided = enable
+        return {"FINISHED"}
+
+
+class PlasmaToggleDoubleSidedSelectOperator(ToolboxOperator, bpy.types.Operator):
+    bl_idname = "mesh.plasma_toggle_double_sided_selected"
+    bl_label = "Toggle Selected Double Sided"
+    bl_description = "Toggles selected meshes double sided value"
+    
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and hasattr(bpy.context, "selected_objects")
+
+    def execute(self, context):
+        mesh_list = [i.data for i in context.selected_objects if i.type == "MESH"]
+        enable = not all((mesh.show_double_sided for mesh in mesh_list))
+        for mesh in mesh_list:
+            mesh.show_double_sided = enable
+        return {"FINISHED"}
+
 
 class PlasmaToggleEnvironmentMapsOperator(ToolboxOperator, bpy.types.Operator):
     bl_idname = "texture.plasma_toggle_environment_maps"

--- a/korman/ui/ui_toolbox.py
+++ b/korman/ui/ui_toolbox.py
@@ -50,6 +50,12 @@ class PlasmaToolboxPanel(ToolboxPanel, bpy.types.Panel):
         col.operator("texture.plasma_toggle_environment_maps", icon="IMAGE_RGB", text="Enable All EnvMaps").enable = True
         col.operator("texture.plasma_toggle_environment_maps", icon="IMAGE_RGB_ALPHA", text="Disable All EnvMaps").enable = False
 
+        # Double Sided Operators
+        col.label("Double Sided:")
+        col.operator("mesh.plasma_toggle_double_sided", icon="MESH_DATA", text="Disable All").enable = False
+        all_double_sided = all((i.data.show_double_sided for i in bpy.context.selected_objects if i.type == "MESH"))
+        col.operator("mesh.plasma_toggle_double_sided_selected", icon="BORDER_RECT", text="Disable Selection" if all_double_sided else "Enable Selection")
+
         col.label("Convert:")
         col.operator("object.plasma_convert_plasma_objects", icon="OBJECT_DATA", text="Plasma Objects")
         col.operator("texture.plasma_convert_layer_opacities", icon="IMAGE_RGB_ALPHA", text="Layer Opacities")


### PR DESCRIPTION
Adds toolbar options to toggle meshes double sided, one to Disable All (handy for incoming PyPRP Ages) and Enable/Disable Selection.

I thought about an Enable All button, but didn't know if there would ever be a reason to use a function like that.