### PR TITLE
DSpan Export Improvements

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -147,6 +147,16 @@ class MaterialConverter:
             "transformCtl": self._export_layer_transform_animation,
         }
 
+    def calc_material_ambient(self, bo, bm) -> hsColorRGBA:
+        emit_scale = bm.emit * 0.5
+        if emit_scale > 0.0:
+            return hsColorRGBA(bm.diffuse_color.r * emit_scale,
+                               bm.diffuse_color.g * emit_scale,
+                               bm.diffuse_color.b * emit_scale,
+                               1.0)
+        else:
+            return utils.color(bpy.context.scene.world.ambient_color)
+
     def _can_export_texslot(self, slot):
         if slot is None or not slot.use:
             return False
@@ -187,7 +197,9 @@ class MaterialConverter:
             self._report.msg("Exporting Material '{}' as single user '{}'", bm.name, mat_name, indent=1)
             hgmat = None
         else:
-            mat_name = bm.name
+            # Ensure that RT-lit objects don't infect the static-lit objects.
+            mat_prefix = "RTLit_" if bo.plasma_modifiers.lighting.rt_lights else ""
+            mat_name = "".join((mat_prefix, bm.name))
             self._report.msg("Exporting Material '{}'", mat_name, indent=1)
             hsgmat = self._mgr.find_key(hsGMaterial, name=mat_name, bl=bo)
             if hsgmat is not None:
@@ -222,7 +234,8 @@ class MaterialConverter:
             if slot.use_stencil:
                 stencils.append((idx, slot))
             else:
-                tex_layer = self.export_texture_slot(bo, bm, hsgmat, slot, idx)
+                tex_name = "{}_{}".format(mat_name, slot.name)
+                tex_layer = self.export_texture_slot(bo, bm, hsgmat, slot, idx, name=tex_name)
                 if restart_pass_next:
                     tex_layer.state.miscFlags |= hsGMatState.kMiscRestartPassHere
                     restart_pass_next = False
@@ -249,7 +262,7 @@ class MaterialConverter:
         # Plasma makes several assumptions that every hsGMaterial has at least one layer. If this
         # material had no Textures, we will need to initialize a default layer
         if not hsgmat.layers:
-            layer = self._mgr.find_create_object(plLayer, name="{}_AutoLayer".format(bm.name), bl=bo)
+            layer = self._mgr.find_create_object(plLayer, name="{}_AutoLayer".format(mat_name), bl=bo)
             self._propagate_material_settings(bo, bm, layer)
             hsgmat.addLayer(layer.key)
 
@@ -349,7 +362,7 @@ class MaterialConverter:
         return hsgmat.key
 
     def export_bumpmap_slot(self, bo, bm, hsgmat, slot, idx):
-        name = "{}_{}".format(bm.name if bm is not None else bo.name, slot.name)
+        name = "{}_{}".format(hsgmat.key.name, slot.name)
         self._report.msg("Exporting Plasma Bumpmap Layers for '{}'", name, indent=2)
 
         # Okay, now we need to make 3 layers for the Du, Dw, and Dv
@@ -1163,6 +1176,20 @@ class MaterialConverter:
     def get_bump_layer(self, bo):
         return self._bump_mats.get(bo, None)
 
+    def get_material_preshade(self, bo, bm, color=None) -> hsColorRGBA:
+        if bo.plasma_modifiers.lighting.rt_lights or bm.emit:
+            return hsColorRGBA.kBlack
+        if color is None:
+            color = bm.diffuse_color
+        return utils.color(color)
+
+    def get_material_runtime(self, bo, bm, color=None) -> hsColorRGBA:
+        if bm.emit:
+            return hsColorRGBA.kBlack
+        if color is None:
+            color = bm.diffuse_color
+        return utils.color(color)
+
     def get_texture_animation_key(self, bo, bm, texture):
         """Finds or creates the appropriate key for sending messages to an animated Texture"""
 
@@ -1204,23 +1231,17 @@ class MaterialConverter:
         if bm.use_shadeless:
             state.shadeFlags |= hsGMatState.kShadeWhite
 
+        if bm.emit:
+            state.shadeFlags |= hsGMatState.kShadeEmissive
+
         # Colors
-        layer.ambient = utils.color(bpy.context.scene.world.ambient_color)
-        layer.preshade = utils.color(bm.diffuse_color)
-        layer.runtime = utils.color(bm.diffuse_color)
+        layer.ambient = self.calc_material_ambient(bo, bm)
+        layer.preshade = self.get_material_preshade(bo, bm)
+        layer.runtime = self.get_material_runtime(bo, bm)
         layer.specular = utils.color(bm.specular_color)
 
         layer.specularPower = min(100.0, float(bm.specular_hardness))
-        layer.LODBias = -1.0 # Seems to be the Plasma default
-
-        if bm.emit > 0.0:
-            # Use the diffuse colour as the emit, scaled by the emit amount
-            # (maximum 2.0, so we'll also scale that by 0.5)
-            emit_scale = bm.emit * 0.5
-            layer.ambient = hsColorRGBA(bm.diffuse_color.r * emit_scale,
-                                        bm.diffuse_color.g * emit_scale,
-                                        bm.diffuse_color.b * emit_scale,
-                                        1.0)
+        layer.LODBias = -1.0
 
     def _requires_single_user(self, bo, bm):
         if bo.data.show_double_sided:

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -279,7 +279,7 @@ class MeshConverter(_MeshManager):
         # TODO: if this is an avatar, we can't be non-preshaded.
         if check_layer_shading_animation(base_layer):
             return False
-        if base_layer.state.shadeFlags & hsGMatState.kShadeEmissive:
+        if material_idx is not None and mesh.materials[material_idx].emit:
             return False
 
         mods = bo.plasma_modifiers

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -279,8 +279,13 @@ class MeshConverter(_MeshManager):
         # TODO: if this is an avatar, we can't be non-preshaded.
         if check_layer_shading_animation(base_layer):
             return False
-        if material_idx is not None and mesh.materials[material_idx].emit:
-            return False
+
+        # Reject emissive and shadeless because the kLiteMaterial equation has lots of options
+        # that are taken away by VtxNonPreshaded that are useful here.
+        if material_idx is not None:
+            bm = mesh.materials[material_idx]
+            if bm.emit or bm.use_shadeless:
+                return False
 
         mods = bo.plasma_modifiers
         if mods.lighting.rt_lights:

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -127,6 +127,9 @@ def poll_animated_objects(self, value):
 def poll_camera_objects(self, value):
     return value.type == "CAMERA"
 
+def poll_drawable_objects(self, value):
+    return value.type == "MESH" and any(value.data.materials)
+
 def poll_empty_objects(self, value):
     return value.type == "EMPTY"
 

--- a/korman/properties/modifiers/__init__.py
+++ b/korman/properties/modifiers/__init__.py
@@ -66,6 +66,10 @@ class PlasmaModifiers(bpy.types.PropertyGroup):
             setattr(cls, i.pl_id, bpy.props.PointerProperty(type=i))
         bpy.types.Object.plasma_modifiers = bpy.props.PointerProperty(type=cls)
 
+    def test_property(self, property : str) -> bool:
+        """Tests a property on all enabled Plasma modifiers"""
+        return any((getattr(i, property) for i in self.modifiers))
+
 
 class PlasmaModifierSpec(bpy.types.PropertyGroup):
     pass

--- a/korman/properties/modifiers/base.py
+++ b/korman/properties/modifiers/base.py
@@ -31,8 +31,28 @@ class PlasmaModifierProperties(bpy.types.PropertyGroup):
         pass
 
     @property
+    def draw_opaque(self):
+        """Render geometry before the avatar"""
+        return False
+
+    @property
+    def draw_framebuf(self):
+        """Render geometry after the avatar but before other blended geometry"""
+        return False
+
+    @property
+    def draw_no_defer(self):
+        """Disallow geometry being sorted into a blending span"""
+        return False
+
+    @property
     def enabled(self):
         return self.display_order >= 0
+
+    @property
+    def face_sort(self):
+        """Indicates that the geometry's faces should be sorted by the engine"""
+        return False
 
     def harvest_actors(self):
         return ()

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -531,6 +531,8 @@ class PlasmaLightingMod(PlasmaModifierProperties):
             return True
         if self.id_data.plasma_object.has_transform_animation:
             return True
+        if mods.collision.enabled and mods.collision.dynamic:
+            return True
         return False
 
 

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -25,6 +25,98 @@ from ...exporter import utils
 from ...exporter.explosions import ExportError
 from ... import idprops
 
+class PlasmaBlendOntoObject(bpy.types.PropertyGroup):
+    blend_onto = PointerProperty(name="Blend Onto",
+                                 description="Object to render first",
+                                 options=set(),
+                                 type=bpy.types.Object,
+                                 poll=idprops.poll_drawable_objects)
+    enabled = BoolProperty(name="Enabled",
+                           default=True,
+                           options=set())
+
+
+class PlasmaBlendMod(PlasmaModifierProperties):
+    pl_id = "blend"
+
+    bl_category = "Render"
+    bl_label = "Blending"
+    bl_description = "Advanced Blending Options"
+
+    render_level = EnumProperty(name="Render Pass",
+                                description="Suggested render pass for this object.",
+                                items=[("AUTO", "(Auto)", "Let Korman decide when to render this object."),
+                                       ("OPAQUE", "Before Avatar", "Prefer for the object to draw before the avatar."),
+                                       ("FRAMEBUF", "Frame Buffer", "Prefer for the object to draw after the avatar but before other blended objects."),
+                                       ("BLEND", "Blended", "Prefer for the object to draw after most other geometry in the blended pass.")],
+                                options=set())
+    sort_faces = EnumProperty(name="Sort Faces",
+                              description="",
+                              items=[("AUTO", "(Auto)", "Let Korman decide if faces should be sorted."),
+                                     ("ALWAYS", "Always", "Force the object's faces to be sorted."),
+                                     ("NEVER", "Never", "Force the object's faces to never be sorted.")],
+                              options=set())
+
+    dependencies = CollectionProperty(type=PlasmaBlendOntoObject)
+    active_dependency_index = IntProperty(options={"HIDDEN"})
+
+    def export(self, exporter, bo, so):
+        # What'er you lookin at?
+        pass
+
+    @property
+    def draw_opaque(self):
+        return self.render_level == "OPAQUE"
+
+    @property
+    def draw_framebuf(self):
+        return self.render_level == "FRAMEBUF"
+
+    @property
+    def draw_no_defer(self):
+        return self.render_level != "BLEND"
+
+    @property
+    def face_sort(self):
+        return self.sort_faces == "ALWAYS"
+
+    @property
+    def no_face_sort(self):
+        return self.sort_faces == "NEVER"
+
+    @property
+    def has_dependencies(self):
+        return bool(self.dependencies)
+
+    @property
+    def has_circular_dependency(self):
+        return self._check_circular_dependency()
+
+    def _check_circular_dependency(self, objects=None):
+        if objects is None:
+            objects = set()
+        elif self.name in objects:
+            return True
+        objects.add(self.name)
+
+        for i in self.iter_dependencies():
+            # New deep copy of the set for each dependency, so an object can be reused as a
+            # dependant's dependant.
+            this_branch = set(objects)
+            sub_mod = i.plasma_modifiers.blend
+            if sub_mod.enabled and sub_mod._check_circular_dependency(this_branch):
+                return True
+        return False
+
+    def iter_dependencies(self):
+        for i in (j.blend_onto for j in self.dependencies if j.blend_onto is not None and j.enabled):
+            yield i
+
+    def sanity_check(self):
+        if self.has_circular_dependency:
+            raise ExportError("'{}': Circular Render Dependency detected!".format(self.name))
+
+
 class PlasmaDecalManagerRef(bpy.types.PropertyGroup):
     enabled = BoolProperty(name="Enabled",
                            default=True,

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -18,6 +18,36 @@ import bpy
 from .. import ui_list
 from ...exporter.mesh import _VERTEX_COLOR_LAYERS
 
+class BlendOntoListUI(bpy.types.UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_property, index=0, flt_flag=0):
+        if item.blend_onto is None:
+            layout.label("[No Object Specified]", icon="ERROR")
+        else:
+            layout.label(item.blend_onto.name, icon="OBJECT_DATA")
+        layout.prop(item, "enabled", text="")
+
+
+def blend(modifier, layout, context):
+    # Warn if there are render dependencies and a manual render level specification -- this
+    # could lead to unpredictable results.
+    layout.alert = modifier.render_level != "AUTO" and bool(modifier.dependencies)
+    layout.prop(modifier, "render_level")
+    layout.alert = False
+    layout.prop(modifier, "sort_faces")
+
+    layout.separator()
+    layout.label("Render Dependencies:")
+    ui_list.draw_modifier_list(layout, "BlendOntoListUI", modifier, "dependencies",
+                              "active_dependency_index", rows=2, maxrows=4)
+    try:
+        dependency_ref = modifier.dependencies[modifier.active_dependency_index]
+    except:
+        pass
+    else:
+        layout.alert = dependency_ref.blend_onto is None
+        layout.prop(dependency_ref, "blend_onto")
+
+
 class DecalMgrListUI(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_property, index=0, flt_flag=0):
         if item.name:


### PR DESCRIPTION
This is designed to fix some issues around non-animated runtime lights not affecting geometry and challenges around alpha transparency and x-ray effects. We do so by properly using the `kLiteVtxNonPreshaded` equation for alpha and runtime lit geometry. Further, preshade and runtime colors are now properly set for runtime lit and emissive layers.

Adds the Render > Blending modifier to ensure dependent objects get sorted into later passes.