### PR TITLE
Add Sound Export Operator Buttons

### DIFF
--- a/korman/operators/op_toolbox.py
+++ b/korman/operators/op_toolbox.py
@@ -16,6 +16,7 @@
 import bpy
 from bpy.props import *
 import pickle
+import itertools
 
 class ToolboxOperator:
     @classmethod
@@ -234,4 +235,40 @@ class PlasmaTogglePlasmaObjectsOperator(ToolboxOperator, bpy.types.Operator):
         enable = not all((i.plasma_object.enabled for i in bpy.context.selected_objects))
         for i in context.selected_objects:
             i.plasma_object.enabled = enable
+        return {"FINISHED"}
+
+
+class PlasmaToggleSoundExportOperator(ToolboxOperator, bpy.types.Operator):
+    bl_idname = "object.plasma_toggle_sound_export"
+    bl_label = "Toggle Sound Export"
+    bl_description = "Toggles the Export function of all sound emitters' files"
+    
+    enable = BoolProperty(name="Enable", description="Sound Export Enable")
+    
+    def execute(self, context):
+        enable = self.enable
+        for i in bpy.data.objects:
+            if i.plasma_modifiers.soundemit is None:
+                continue
+            for sound in i.plasma_modifiers.soundemit.sounds:
+                sound.package = enable
+        return {"FINISHED"}
+
+
+class PlasmaToggleSoundExportSelectedOperator(ToolboxOperator, bpy.types.Operator):
+    bl_idname = "object.plasma_toggle_sound_export_selected"
+    bl_label = "Toggle Selected Sound Export"
+    bl_description = "Toggles the Export function of selected sound emitters' files."
+    
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and hasattr(bpy.context, "selected_objects")
+    
+    def execute(self, context):
+        enable = not all((i.package for i in itertools.chain.from_iterable(i.plasma_modifiers.soundemit.sounds for i in bpy.context.selected_objects)))
+        for i in context.selected_objects:
+            if i.plasma_modifiers.soundemit is None:
+                continue
+            for sound in i.plasma_modifiers.soundemit.sounds:
+                sound.package = enable
         return {"FINISHED"}

--- a/korman/ui/ui_toolbox.py
+++ b/korman/ui/ui_toolbox.py
@@ -14,6 +14,7 @@
 #    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
+import itertools
 
 class ToolboxPanel:
     bl_category = "Tools"
@@ -44,6 +45,12 @@ class PlasmaToolboxPanel(ToolboxPanel, bpy.types.Panel):
         col.label("Plasma Pages:")
         col.operator("object.plasma_move_selection_to_page", icon="BOOKMARKS", text="Move to Page")
         col.operator("object.plasma_select_page_objects", icon="RESTRICT_SELECT_OFF", text="Select Objects")
+        
+        col.label("Package Sounds:")
+        col.operator("object.plasma_toggle_sound_export", icon="MUTE_IPO_OFF", text="Enable All").enable = True
+        all_sounds_export = all((i.package for i in itertools.chain.from_iterable(i.plasma_modifiers.soundemit.sounds for i in bpy.context.selected_objects if i.plasma_modifiers.soundemit.enabled)))
+        col.operator("object.plasma_toggle_sound_export_selected", icon="OUTLINER_OB_SPEAKER", text="Disable Selection" if all_sounds_export else "Enable Selection")
+        col.operator("object.plasma_toggle_sound_export", icon="MUTE_IPO_ON", text="Disable All").enable = False
 
         col.label("Textures:")
         col.operator("texture.plasma_enable_all_textures", icon="TEXTURE", text="Enable All")


### PR DESCRIPTION
Adds buttons to the toolbar to enable and disable export/packaging of sounds (WIP).

Some issues at the moment:

- Enable/Disable selected is not toggling properly, both in function and button text (currently disabled for now).

- Enable/Disable All buttons are working, but the effect (ie the "Export" checkbox) does not display immediately on-screen until the cursor hovers over the sound mod.