### PR TITLE
Add plAgeGlobalAnim support

### DIFF
--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -73,10 +73,7 @@ class AnimationConverter:
         # to be listed on the SceneObject in a specific order. D'OH! So, always use these funcs.
         agmod, agmaster = self.get_anigraph_objects(bo, so)
         anim_mod = bo.plasma_modifiers.animation
-        if anim_mod.obj_sdl_anim:
-            atcanim = self._mgr.find_create_object(plAgeGlobalAnim, so=so)
-        else:
-            atcanim = self._mgr.find_create_object(plATCAnim, so=so)
+        atcanim = self._mgr.find_create_object(anim_mod.anim_type, so=so)
 
         # Add the animation data to the ATC
         for i in applicators:
@@ -93,26 +90,23 @@ class AnimationConverter:
                 if i is not None:
                     yield i.frame_range[index]
         atcanim.name = "(Entire Animation)"
-        def anim_range_type(plAGAnim):
-            if anim_mod.obj_sdl_anim:
-                atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, data_action, index=0)))
-                atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, data_action, index=1)))
-                atcanim.globalVarName = anim_mod.obj_sdl_anim
-            else:
-                atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, data_action, index=0)))
-                atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, data_action, index=1)))
-                # Fixme? Not sure if we really need to expose this...
-                atcanim.easeInMin = 1.0
-                atcanim.easeInMax = 1.0
-                atcanim.easeInLength = 1.0
-                atcanim.easeOutMin = 1.0
-                atcanim.easeOutMax = 1.0
-                atcanim.easeOutLength = 1.0
-
+        sdl_name = bo.plasma_modifiers.animation.obj_sdl_anim
+        atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, data_action, index=0)))
+        atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, data_action, index=1)))
+        if isinstance(atcanim, plAgeGlobalAnim):
+            atcanim.globalVarName = anim_mod.obj_sdl_anim
+        if isinstance(atcanim, plATCAnim):
         # Marker points
-        if obj_action is not None and anim_mod is None:
-            for marker in obj_action.pose_markers:
-                atcanim.setMarker(marker.name, self._convert_frame_time(marker.frame))
+            if obj_action is not None and not anim_data.obj_sdl_anim:
+                for marker in obj_action.pose_markers:
+                    atcanim.setMarker(marker.name, self._convert_frame_time(marker.frame))
+            # Fixme? Not sure if we really need to expose this...
+            atcanim.easeInMin = 1.0
+            atcanim.easeInMax = 1.0
+            atcanim.easeInLength = 1.0
+            atcanim.easeOutMin = 1.0
+            atcanim.easeOutMax = 1.0
+            atcanim.easeOutLength = 1.0
 
     def _convert_camera_animation(self, bo, so, obj_fcurves, data_fcurves):
         if data_fcurves:

--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -90,14 +90,14 @@ class AnimationConverter:
                 if i is not None:
                     yield i.frame_range[index]
         atcanim.name = "(Entire Animation)"
-        sdl_name = bo.plasma_modifiers.animation.obj_sdl_anim
+        sdl_name = anim_mod.obj_sdl_anim
         atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, data_action, index=0)))
         atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, data_action, index=1)))
         if isinstance(atcanim, plAgeGlobalAnim):
             atcanim.globalVarName = anim_mod.obj_sdl_anim
         if isinstance(atcanim, plATCAnim):
-        # Marker points
-            if obj_action is not None and not anim_data.obj_sdl_anim:
+            # Marker points
+            if obj_action is not None:
                 for marker in obj_action.pose_markers:
                     atcanim.setMarker(marker.name, self._convert_frame_time(marker.frame))
             # Fixme? Not sure if we really need to expose this...

--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -22,7 +22,7 @@ import weakref
 
 from . import utils
 
-class AnimationConverter:
+class AnimationConverter(plAGAnim):
     def __init__(self, exporter):
         self._exporter = weakref.ref(exporter)
         self._bl_fps = bpy.context.scene.render.fps
@@ -75,7 +75,7 @@ class AnimationConverter:
         anim_data = bo.plasma_modifiers.animation
         if anim_data.obj_sdl_anim:
             atcanim = self._mgr.find_create_object(plAgeGlobalAnim, so=so)
-        else:
+        elif anim_data.obj_sdl_anim is None:
             atcanim = self._mgr.find_create_object(plATCAnim, so=so)
 
         # Add the animation data to the ATC
@@ -96,7 +96,7 @@ class AnimationConverter:
         if anim_data.obj_sdl_anim:
             atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, index=0)))
             atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, index=1)))
-        else:
+        elif anim_data.obj_sdl_anim is None:
             atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, data_action, index=0)))
             atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, data_action, index=1)))
 
@@ -105,18 +105,17 @@ class AnimationConverter:
             for marker in obj_action.pose_markers:
                 atcanim.setMarker(marker.name, self._convert_frame_time(marker.frame))
 
-        def set_anim_params(plAGAnim):
-            sdl_name = bo.plasma_modifiers.animation.obj_sdl_anim
-            if sdl_name:
-                atcanim.globalVarName = sdl_name
-            else:
-                # Fixme? Not sure if we really need to expose this...
-                atcanim.easeInMin = 1.0
-                atcanim.easeInMax = 1.0
-                atcanim.easeInLength = 1.0
-                atcanim.easeOutMin = 1.0
-                atcanim.easeOutMax = 1.0
-                atcanim.easeOutLength = 1.0
+        sdl_name = bo.plasma_modifiers.animation.obj_sdl_anim
+        if sdl_name:
+            atcanim.globalVarName = sdl_name
+        elif sdl_name is None:
+            # Fixme? Not sure if we really need to expose this...
+            atcanim.easeInMin = 1.0
+            atcanim.easeInMax = 1.0
+            atcanim.easeInLength = 1.0
+            atcanim.easeOutMin = 1.0
+            atcanim.easeOutMax = 1.0
+            atcanim.easeOutLength = 1.0
 
     def _convert_camera_animation(self, bo, so, obj_fcurves, data_fcurves):
         if data_fcurves:

--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -22,7 +22,7 @@ import weakref
 
 from . import utils
 
-class AnimationConverter(plAGAnim):
+class AnimationConverter:
     def __init__(self, exporter):
         self._exporter = weakref.ref(exporter)
         self._bl_fps = bpy.context.scene.render.fps
@@ -72,10 +72,10 @@ class AnimationConverter(plAGAnim):
         # There is a race condition in the client with animation loading. It expects for modifiers
         # to be listed on the SceneObject in a specific order. D'OH! So, always use these funcs.
         agmod, agmaster = self.get_anigraph_objects(bo, so)
-        anim_data = bo.plasma_modifiers.animation
-        if anim_data.obj_sdl_anim:
+        anim_mod = bo.plasma_modifiers.animation
+        if anim_mod.obj_sdl_anim:
             atcanim = self._mgr.find_create_object(plAgeGlobalAnim, so=so)
-        elif anim_data.obj_sdl_anim is None:
+        else:
             atcanim = self._mgr.find_create_object(plATCAnim, so=so)
 
         # Add the animation data to the ATC
@@ -93,29 +93,26 @@ class AnimationConverter(plAGAnim):
                 if i is not None:
                     yield i.frame_range[index]
         atcanim.name = "(Entire Animation)"
-        if anim_data.obj_sdl_anim:
-            atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, index=0)))
-            atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, index=1)))
-        elif anim_data.obj_sdl_anim is None:
-            atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, data_action, index=0)))
-            atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, data_action, index=1)))
+        def anim_range_type(plAGAnim):
+            if anim_mod.obj_sdl_anim:
+                atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, data_action, index=0)))
+                atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, data_action, index=1)))
+                atcanim.globalVarName = anim_mod.obj_sdl_anim
+            else:
+                atcanim.start = self._convert_frame_time(min(get_ranges(obj_action, data_action, index=0)))
+                atcanim.end = self._convert_frame_time(max(get_ranges(obj_action, data_action, index=1)))
+                # Fixme? Not sure if we really need to expose this...
+                atcanim.easeInMin = 1.0
+                atcanim.easeInMax = 1.0
+                atcanim.easeInLength = 1.0
+                atcanim.easeOutMin = 1.0
+                atcanim.easeOutMax = 1.0
+                atcanim.easeOutLength = 1.0
 
         # Marker points
-        if obj_action is not None and anim_data.obj_sdl_anim is None:
+        if obj_action is not None and anim_mod is None:
             for marker in obj_action.pose_markers:
                 atcanim.setMarker(marker.name, self._convert_frame_time(marker.frame))
-
-        sdl_name = bo.plasma_modifiers.animation.obj_sdl_anim
-        if sdl_name:
-            atcanim.globalVarName = sdl_name
-        elif sdl_name is None:
-            # Fixme? Not sure if we really need to expose this...
-            atcanim.easeInMin = 1.0
-            atcanim.easeInMax = 1.0
-            atcanim.easeInLength = 1.0
-            atcanim.easeOutMin = 1.0
-            atcanim.easeOutMax = 1.0
-            atcanim.easeOutLength = 1.0
 
     def _convert_camera_animation(self, bo, so, obj_fcurves, data_fcurves):
         if data_fcurves:

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -60,6 +60,9 @@ class PlasmaAnimationModifier(ActionModifier, PlasmaModifierProperties):
                                 description="Marker indicating where the default loop begins")
     loop_end = StringProperty(name="Loop End",
                               description="Marker indicating where the default loop ends")
+    obj_sdl_anim = StringProperty(name="SDL Animation",
+                                  description="Name of the SDL variable to use for this animation",
+                                  options=set())
 
     def export(self, exporter, bo, so):
         action = self.blender_action

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -67,33 +67,37 @@ class PlasmaAnimationModifier(ActionModifier, PlasmaModifierProperties):
     def export(self, exporter, bo, so):
         action = self.blender_action
 
-        atcanim = exporter.mgr.find_create_object(plATCAnim, so=so)
-        atcanim.autoStart = self.auto_start
-        atcanim.loop = self.loop
-
-        # Simple start and loop info
-        if action is not None:
-            markers = action.pose_markers
-            initial_marker = markers.get(self.initial_marker)
-            if initial_marker is not None:
-                atcanim.initial = _convert_frame_time(initial_marker.frame)
-            else:
-                atcanim.initial = -1.0
-            if self.loop:
-                loop_start = markers.get(self.loop_start)
-                if loop_start is not None:
-                    atcanim.loopStart = _convert_frame_time(loop_start.frame)
-                else:
-                    atcanim.loopStart = atcanim.start
-                loop_end = markers.get(self.loop_end)
-                if loop_end is not None:
-                    atcanim.loopEnd = _convert_frame_time(loop_end.frame)
-                else:
-                    atcanim.loopEnd = atcanim.end
+        anim_data = bo.plasma_modifiers.animation
+        if anim_data.obj_sdl_anim:
+            atcanim = exporter.mgr.find_create_object(plAgeGlobalAnim, so=so)
         else:
-            if self.loop:
-                atcanim.loopStart = atcanim.start
-                atcanim.loopEnd = atcanim.end
+            atcanim = exporter.mgr.find_create_object(plATCAnim, so=so)
+            atcanim.autoStart = self.auto_start
+            atcanim.loop = self.loop
+
+            # Simple start and loop info for ATC
+            if action is not None:
+                markers = action.pose_markers
+                initial_marker = markers.get(self.initial_marker)
+                if initial_marker is not None:
+                    atcanim.initial = _convert_frame_time(initial_marker.frame)
+                else:
+                    atcanim.initial = -1.0
+                if self.loop:
+                    loop_start = markers.get(self.loop_start)
+                    if loop_start is not None:
+                        atcanim.loopStart = _convert_frame_time(loop_start.frame)
+                    else:
+                        atcanim.loopStart = atcanim.start
+                    loop_end = markers.get(self.loop_end)
+                    if loop_end is not None:
+                        atcanim.loopEnd = _convert_frame_time(loop_end.frame)
+                    else:
+                        atcanim.loopEnd = atcanim.end
+            else:
+                if self.loop:
+                    atcanim.loopStart = atcanim.start
+                    atcanim.loopEnd = atcanim.end
 
 
 class AnimGroupObject(idprops.IDPropObjectMixin, bpy.types.PropertyGroup):

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -73,7 +73,6 @@ class PlasmaAnimationModifier(ActionModifier, PlasmaModifierProperties):
         anim_mod = bo.plasma_modifiers.animation
         atcanim = exporter.mgr.find_create_object(anim_mod.anim_type, so=so)
         if not isinstance(atcanim, plAgeGlobalAnim):
-            atcanim = exporter.mgr.find_create_object(plATCAnim, so=so)
             atcanim.autoStart = self.auto_start
             atcanim.loop = self.loop
 

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -71,10 +71,8 @@ class PlasmaAnimationModifier(ActionModifier, PlasmaModifierProperties):
     def export(self, exporter, bo, so):
         action = self.blender_action
         anim_mod = bo.plasma_modifiers.animation
-        anim = exporter.mgr.find_create_object(anim_mod.anim_type, so=so)
-        if isinstance(anim, plAgeGlobalAnim):
-            atcanim = exporter.mgr.find_create_object(plAgeGlobalAnim, so=so)
-        else:
+        atcanim = exporter.mgr.find_create_object(anim_mod.anim_type, so=so)
+        if not isinstance(atcanim, plAgeGlobalAnim):
             atcanim = exporter.mgr.find_create_object(plATCAnim, so=so)
             atcanim.autoStart = self.auto_start
             atcanim.loop = self.loop

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -64,11 +64,15 @@ class PlasmaAnimationModifier(ActionModifier, PlasmaModifierProperties):
                                   description="Name of the SDL variable to use for this animation",
                                   options=set())
 
+    @property
+    def anim_type(self):
+        return plAgeGlobalAnim if self.obj_sdl_anim else plATCAnim
+
     def export(self, exporter, bo, so):
         action = self.blender_action
-
-        anim_data = bo.plasma_modifiers.animation
-        if anim_data.obj_sdl_anim:
+        anim_mod = bo.plasma_modifiers.animation
+        anim = exporter.mgr.find_create_object(anim_mod.anim_type, so=so)
+        if isinstance(anim, plAgeGlobalAnim):
             atcanim = exporter.mgr.find_create_object(plAgeGlobalAnim, so=so)
         else:
             atcanim = exporter.mgr.find_create_object(plATCAnim, so=so)

--- a/korman/ui/modifiers/anim.py
+++ b/korman/ui/modifiers/anim.py
@@ -32,6 +32,7 @@ def animation(modifier, layout, context):
         return
 
     split = layout.split()
+    col = layout.column()
     col = split.column()
     col.prop(modifier, "auto_start")
     col = split.column()
@@ -40,12 +41,13 @@ def animation(modifier, layout, context):
     if action:
         layout.prop_search(modifier, "initial_marker", action, "pose_markers", icon="PMARKER")
         col = layout.column()
-        col.enabled = modifier.loop
+        col.enabled = modifier.loop and not modifier.obj_sdl_anim
         col.prop_search(modifier, "loop_start", action, "pose_markers", icon="PMARKER")
         col.prop_search(modifier, "loop_end", action, "pose_markers", icon="PMARKER")
-    
-    col.label("SDL Animation:")
-    col.prop(modifier, "obj_sdl_anim", text="")
+        col = layout.column()
+        col.label("SDL Animation:")
+        col.prop(modifier, "obj_sdl_anim", text="")
+        
 
 def animation_filter(modifier, layout, context):
     split = layout.split()

--- a/korman/ui/modifiers/anim.py
+++ b/korman/ui/modifiers/anim.py
@@ -43,8 +43,8 @@ def animation(modifier, layout, context):
         col.enabled = modifier.loop and not modifier.obj_sdl_anim
         col.prop_search(modifier, "loop_start", action, "pose_markers", icon="PMARKER")
         col.prop_search(modifier, "loop_end", action, "pose_markers", icon="PMARKER")
-        layout.separator()
-        layout.prop(modifier, "obj_sdl_anim")
+    layout.separator()
+    layout.prop(modifier, "obj_sdl_anim")
         
 def animation_filter(modifier, layout, context):
     split = layout.split()

--- a/korman/ui/modifiers/anim.py
+++ b/korman/ui/modifiers/anim.py
@@ -32,7 +32,6 @@ def animation(modifier, layout, context):
         return
 
     split = layout.split()
-    col = layout.column()
     col = split.column()
     col.prop(modifier, "auto_start")
     col = split.column()
@@ -44,11 +43,9 @@ def animation(modifier, layout, context):
         col.enabled = modifier.loop and not modifier.obj_sdl_anim
         col.prop_search(modifier, "loop_start", action, "pose_markers", icon="PMARKER")
         col.prop_search(modifier, "loop_end", action, "pose_markers", icon="PMARKER")
-        col = layout.column()
-        col.label("SDL Animation:")
-        col.prop(modifier, "obj_sdl_anim", text="")
+        layout.separator()
+        layout.prop(modifier, "obj_sdl_anim")
         
-
 def animation_filter(modifier, layout, context):
     split = layout.split()
 

--- a/korman/ui/modifiers/anim.py
+++ b/korman/ui/modifiers/anim.py
@@ -43,6 +43,9 @@ def animation(modifier, layout, context):
         col.enabled = modifier.loop
         col.prop_search(modifier, "loop_start", action, "pose_markers", icon="PMARKER")
         col.prop_search(modifier, "loop_end", action, "pose_markers", icon="PMARKER")
+    
+    col.label("SDL Animation:")
+    col.prop(modifier, "obj_sdl_anim", text="")
 
 def animation_filter(modifier, layout, context):
     split = layout.split()


### PR DESCRIPTION
Adds SDL Global animation to Korman per #204 (work in progress).

What it does so far:

* Adds SDL field to Animation modifier. ~~Note that it's only available if "Loop Anim" is selected (is this OK?).~~
* Creates ~~what appears to be~~ an ~~valid~~ Age Global Animation (plAgeGlobalAnim) entry into the PRP files ~~aside from one flaw (see below)~~.

A few things to fix:

* ~~SDL parameter from modifier isn't being written to AgeGlobalAnim's "GlobalVarName" entry.~~ Fixed thanks to dpogue.
* ~~Global Animation being created for non-object animations (layer animations), causing glitching.~~
* ~~Some extra ATC parameters (says it needs fixing?)~~
* "Writing Age data..." part of export is hanging for several seconds, most likely due to mah hacks. 😉 
* ~~Global Animation also creates a near-empty ATCAnim.~~