### PR TITLE
Fix Exponential Fog

### DIFF
--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -321,8 +321,8 @@ class ExportManager:
                 stream.writeLine("Graphics.Renderer.Fog.SetDefColor {} {} {}".format(*fni.fog_color))
                 if fni.fog_method == "linear":
                     stream.writeLine("Graphics.Renderer.Fog.SetDefLinear {} {} {}".format(fni.fog_start, fni.fog_end, fni.fog_density))
-                elif fni.fog_method == "exp2":
-                    stream.writeLine("Graphics.Renderer.Fog.SetDefExp2 {} {}".format(fni.fog_end, fni.fog_density))
+                elif fni.fog_method == "exp":
+                    stream.writeLine("Graphics.Renderer.Fog.SetDefExp {} {}".format(fni.fog_end, fni.fog_density))
 
     def _write_pages(self):
         age_name = self._age_info.name

--- a/korman/properties/prop_world.py
+++ b/korman/properties/prop_world.py
@@ -31,7 +31,7 @@ class PlasmaFni(bpy.types.PropertyGroup):
     fog_method = EnumProperty(name="Fog Type",
                               items=[
                                      ("linear", "Linear", "Linear Fog"),
-                                     ("exp2", "Exponential", "Exponential Fog"),
+                                     ("exp", "Exponential", "Exponential Fog"),
                                      ("none", "None", "Use fog from the previous age")
                                     ])
     fog_start = FloatProperty(name="Start",

--- a/korman/ui/ui_world.py
+++ b/korman/ui/ui_world.py
@@ -262,6 +262,10 @@ class PlasmaEnvironmentPanel(AgeButtonsPanel, bpy.types.Panel):
         layout = self.layout
         fni = context.world.plasma_fni
 
+        # warn about reversed linear fog values
+        if fni.fog_method == "linear" and fni.fog_start >= fni.fog_end and (fni.fog_start + fni.fog_end) != 0:
+            layout.label(text="Fog Start Value should be less than the End Value", icon="ERROR")
+
         # basic colors
         split = layout.split()
         col = split.column()


### PR DESCRIPTION
This was something minor that came up awhile back. For some reason, SetDefExp2 type fog doesn't seem to work upon export in either MOUL or PotS/CC, but regular SetDefExp does. This is just a proposed minor change to use the regular SetDefExp option if fixing the other is too big a task.

Yeah, could probably have left everything except `Graphics.Renderer.Fog.SetDefExp` alone, but I figured we'd want things uniform across the board. 😉 