### PR TITLE
More DSpan material fixes

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -188,7 +188,7 @@ class MaterialConverter:
             hgmat = None
         else:
             # Ensure that RT-lit objects don't infect the static-lit objects.
-            mat_prefix = "RTLit_" if bo.plasma_modifiers.lighting.rt_lights else ""
+            mat_prefix = "RTLit_" if bo.plasma_modifiers.lighting.force_rt_lights and not bm.use_shadeless else ""
             mat_name = "".join((mat_prefix, bm.name))
             self._report.msg("Exporting Material '{}'", mat_name, indent=1)
             hsgmat = self._mgr.find_key(hsGMaterial, name=mat_name, bl=bo)
@@ -1177,14 +1177,17 @@ class MaterialConverter:
             return utils.color(bpy.context.scene.world.ambient_color)
 
     def get_material_preshade(self, bo, bm, color=None) -> hsColorRGBA:
-        if bo.plasma_modifiers.lighting.rt_lights:
+        if bo.plasma_modifiers.lighting.enabled and bo.plasma_modifiers.lighting.force_rt_lights and not bm.use_shadeless:
             return hsColorRGBA.kBlack
         if color is None:
             color = bm.diffuse_color
         return utils.color(color)
 
     def get_material_runtime(self, bo, bm, color=None) -> hsColorRGBA:
-        if not bo.plasma_modifiers.lighting.rt_lights:
+        if bo.plasma_modifiers.lighting.enabled:
+            if not bo.plasma_modifiers.lighting.force_rt_lights and bm.use_shadeless:
+                return hsColorRGBA.kBlack
+        if bo.plasma_modifiers.water_basic.enabled:
             return hsColorRGBA.kBlack
         if color is None:
             color = bm.diffuse_color

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -289,7 +289,7 @@ class MeshConverter(_MeshManager):
                 return False
 
         mods = bo.plasma_modifiers
-        if mods.lighting.rt_lights:
+        if mods.lighting.force_rt_lights:
             return True
         if mods.lightmap.bake_lightmap:
             return True
@@ -326,7 +326,7 @@ class MeshConverter(_MeshManager):
             geospan.props |= plGeometrySpan.kDiffuseFoldedIn
 
         mods = bo.plasma_modifiers
-        if mods.lighting.rt_lights:
+        if mods.lighting.force_rt_lights:
             geospan.props |= plGeometrySpan.kPropRunTimeLight
         if not bm.use_shadows:
             geospan.props |= plGeometrySpan.kPropNoShadow


### PR DESCRIPTION
Fixes a few material errors that cropped up after PR #210  and detailed in issue #228 , but could do with some more checking.

Changes include:
- sanity checks to make sure the Lighting Info modifier is actually enabled. This is because if the mod had been used, then deleted, Korman still seems to read the bool values anyway.
- changed instances of `lighting.rt_lights` to `lighting.force_rt_lights`.
- Exception for runtime color and wavesets. The runtime must be black in that case or the waveset is too bright.