### PR TITLE
More DSpan Lighting Fixes

### DIFF
--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -16,6 +16,7 @@
 import bpy
 from pathlib import Path
 from PyHSPlasma import *
+from typing import Iterable
 import weakref
 
 from . import explosions
@@ -189,6 +190,13 @@ class ExportManager:
             return plEncryptedStream.kEncAes
         else:
             return plEncryptedStream.kEncXtea
+
+    def find_interfaces(self, pClass, so : plSceneObject) -> Iterable[plObjInterface]:
+        assert issubclass(pClass, plObjInterface)
+
+        for i in (i.object for i in so.interfaces):
+            if isinstance(i, pClass):
+                yield i
 
     def find_create_key(self, pClass, bl=None, name=None, so=None):
         key = self.find_key(pClass, bl, name, so)

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -1184,7 +1184,7 @@ class MaterialConverter:
         return utils.color(color)
 
     def get_material_runtime(self, bo, bm, color=None) -> hsColorRGBA:
-        if not bo.plasma_modifiers.lighting.rt_lights:
+        if not bo.plasma_modifiers.lighting.preshade:
             return hsColorRGBA.kBlack
         if color is None:
             color = bm.diffuse_color


### PR DESCRIPTION
This is an attempt to address some more issues with runtime lighting, Particularly, we now force any light attached to a PFM to be `kLPMovable` - because the only reason you would attach a light to a PFM is to either warp it or turn it on/off. Further, we now export the layer runtime color as the material diffuse unless preshading is explicitly off. The behavior change is subtle, but we only want to set runtime to black in the case of purely dynamic lighting. Otherwise, we end up restricting receiving runtime lighting to only objects that are `kLiteVtxNonPreshaded` because `kLiteMaterial` multiples the runtime color by the lamp color.