### PR TITLE
Round funny values to hide float precision details.

### DIFF
--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -321,16 +321,16 @@ class ExportManager:
 
         with output.generate_dat_file(f, enc=self._encryption) as stream:
             fni = bpy.context.scene.world.plasma_fni
-            stream.writeLine("Graphics.Renderer.SetClearColor {} {} {}".format(*fni.clear_color))
-            stream.writeLine("Graphics.Renderer.SetYon {}".format(fni.yon))
+            stream.writeLine("Graphics.Renderer.SetClearColor {.2f} {.2f} {.2f}".format(*fni.clear_color))
+            stream.writeLine("Graphics.Renderer.SetYon {.1f}".format(fni.yon))
             if fni.fog_method == "none":
                 stream.writeLine("Graphics.Renderer.Fog.SetDefLinear 0 0 0")
             else:
-                stream.writeLine("Graphics.Renderer.Fog.SetDefColor {} {} {}".format(*fni.fog_color))
+                stream.writeLine("Graphics.Renderer.Fog.SetDefColor {.2f} {.2f} {.2f}".format(*fni.fog_color))
                 if fni.fog_method == "linear":
-                    stream.writeLine("Graphics.Renderer.Fog.SetDefLinear {} {} {}".format(fni.fog_start, fni.fog_end, fni.fog_density))
+                    stream.writeLine("Graphics.Renderer.Fog.SetDefLinear {.2f} {.2f} {.2f}".format(fni.fog_start, fni.fog_end, fni.fog_density))
                 elif fni.fog_method == "exp":
-                    stream.writeLine("Graphics.Renderer.Fog.SetDefExp {} {}".format(fni.fog_end, fni.fog_density))
+                    stream.writeLine("Graphics.Renderer.Fog.SetDefExp {.2f} {.2f}".format(fni.fog_end, fni.fog_density))
 
     def _write_pages(self):
         age_name = self._age_info.name


### PR DESCRIPTION
This rounds the funny file values so that long strings of float imprecision errors don't wind up in the exported funny files, making them even funnier than they already are.