### PR TITLE
Add First Person Camera Object

### DIFF
--- a/korman/exporter/camera.py
+++ b/korman/exporter/camera.py
@@ -162,6 +162,14 @@ class CameraConverter:
         # Done already?
         return brain
 
+    def _export_firstperson_camera(self, so, bo, props):
+        brain = self._mgr.find_create_object(plCameraBrain1_FirstPerson, so=so)
+        self._convert_brain(so, bo, props, brain)
+
+        # Copy pasta the follow values for FP cam
+        brain.offset = hsVector3(*props.pos_offset)
+        return brain
+
     def _export_fixed_camera(self, so, bo, props):
         if props.anim_enabled:
             self._exporter().animation.convert_object_animations(bo, so)

--- a/korman/properties/prop_camera.py
+++ b/korman/properties/prop_camera.py
@@ -22,7 +22,8 @@ from .. import idprops
 camera_types = [("circle", "Circle Camera", "The camera circles a fixed point"),
                 ("follow", "Follow Camera", "The camera follows an object"),
                 ("fixed", "Fixed Camera", "The camera is fixed in one location"),
-                ("rail", "Rail Camera", "The camera follows an object by moving along a line")]
+                ("rail", "Rail Camera", "The camera follows an object by moving along a line"),
+                ("firstperson", "First Person", "Simulates first person view and disappears avatar")]
 
 class PlasmaTransition(bpy.types.PropertyGroup):
     poa_acceleration = FloatProperty(name="PoA Acceleration",

--- a/korman/ui/ui_camera.py
+++ b/korman/ui/ui_camera.py
@@ -92,7 +92,7 @@ def draw_camera_poa_props(layout, cam_type, props):
     col.prop(trans, "poa_deceleration", text="Deceleration")
     col.prop(trans, "poa_velocity", text="Maximum Velocity")
     col = col.column()
-    col.active = cam_type == "follow"
+    col.active = cam_type == "follow" or cam_type == "firstperson"
     col.prop(trans, "poa_cut", text="Cut Animation")
 
     # PoA Offset
@@ -118,12 +118,12 @@ def draw_camera_pos_props(layout, cam_type, props):
     _draw_alert_prop(col, trans, "pos_velocity", cam_type,
                      alert_cam="rail", max=10.0, text="Maximum Velocity")
     col = col.column()
-    col.active = cam_type == "follow"
+    col.active = cam_type == "follow" or cam_type == "firstperson"
     col.prop(trans, "pos_cut", text="Cut Animation")
 
     # Position Offsets
     col = split.column()
-    col.active = cam_type == "follow"
+    col.active = cam_type == "follow" or cam_type == "firstperson"
     col.label("Position Offset:")
     col.prop(props, "pos_offset", text="")
     col.prop(props, "pos_worldspace")

--- a/korman/ui/ui_camera.py
+++ b/korman/ui/ui_camera.py
@@ -92,7 +92,7 @@ def draw_camera_poa_props(layout, cam_type, props):
     col.prop(trans, "poa_deceleration", text="Deceleration")
     col.prop(trans, "poa_velocity", text="Maximum Velocity")
     col = col.column()
-    col.active = cam_type == "follow" or cam_type == "firstperson"
+    col.active = cam_type in {"firstperson", "follow"}
     col.prop(trans, "poa_cut", text="Cut Animation")
 
     # PoA Offset
@@ -118,12 +118,12 @@ def draw_camera_pos_props(layout, cam_type, props):
     _draw_alert_prop(col, trans, "pos_velocity", cam_type,
                      alert_cam="rail", max=10.0, text="Maximum Velocity")
     col = col.column()
-    col.active = cam_type == "follow" or cam_type == "firstperson"
+    col.active = cam_type in {"firstperson", "follow"}
     col.prop(trans, "pos_cut", text="Cut Animation")
 
     # Position Offsets
     col = split.column()
-    col.active = cam_type == "follow" or cam_type == "firstperson"
+    col.active = cam_type in {"firstperson", "follow"}
     col.label("Position Offset:")
     col.prop(props, "pos_offset", text="")
     col.prop(props, "pos_worldspace")


### PR DESCRIPTION
Adds support for first person camera objects such as the baron's office desk. Disappears the avatar as well.