### PR TITLE
Toggle EnvMap Avatar Render

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -666,7 +666,7 @@ class MaterialConverter:
         pl_env.hither = bl_env.clip_start
         pl_env.yon = bl_env.clip_end
         pl_env.refreshRate = 0.01 if bl_env.source == "ANIMATED" else 0.0
-        pl_env.incCharacters = True
+        pl_env.incCharacters = True if texture.plasma_layer.envmap_addavatar else False
 
         # Perhaps the DEM/DCM fog should be separately configurable at some point?
         pl_fog = bpy.context.scene.world.plasma_fni

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -666,7 +666,7 @@ class MaterialConverter:
         pl_env.hither = bl_env.clip_start
         pl_env.yon = bl_env.clip_end
         pl_env.refreshRate = 0.01 if bl_env.source == "ANIMATED" else 0.0
-        pl_env.incCharacters = True if texture.plasma_layer.envmap_addavatar else False
+        pl_env.incCharacters = texture.plasma_layer.envmap_addavatar
 
         # Perhaps the DEM/DCM fog should be separately configurable at some point?
         pl_fog = bpy.context.scene.world.plasma_fni

--- a/korman/properties/prop_texture.py
+++ b/korman/properties/prop_texture.py
@@ -48,6 +48,10 @@ class PlasmaLayer(bpy.types.PropertyGroup):
                                        default=(1.0, 1.0, 1.0),
                                        subtype="COLOR")
 
+    envmap_addavatar = BoolProperty(name="Render Avatars",
+                                    description="Toggle the rendering of avatars in the environment map",
+                                    default=True)
+
     vis_regions = CollectionProperty(name="Visibility Regions",
                                      type=EnvMapVisRegion)
     active_region_index = IntProperty(options={"HIDDEN"})

--- a/korman/ui/ui_texture.py
+++ b/korman/ui/ui_texture.py
@@ -43,6 +43,7 @@ class PlasmaEnvMapPanel(TextureButtonsPanel, bpy.types.Panel):
 
         if envmap.source in {"ANIMATED", "STATIC"}:
             layout.prop(layer_props, "envmap_color")
+            layout.prop(layer_props, "envmap_addavatar")
             layout.separator()
 
             layout.label("Visibility Sets:")


### PR DESCRIPTION
Adds a Bool property in the Plasma Environment Map panel to toggle avatar rending (fixes some waveset rendering problems)