### PR TITLE
Convert layer offsets to Plasma's space

### DIFF
--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -420,7 +420,7 @@ class AnimationConverter:
             scale = kwargs[scale_path]
 
             translation = hsVector3(pos[0] - (scale[0] - 1.0) / 2.0,
-                                    1.0 - pos[1] - (scale[1] - 1.0) / 2.0,
+                                    -pos[1] - (scale[1] - 1.0) / 2.0,
                                     pos[2] - (scale[2] - 1.0) / 2.0)
             matrix = hsMatrix44()
             matrix.setTranslate(translation)

--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -419,8 +419,11 @@ class AnimationConverter:
             pos = kwargs[pos_path]
             scale = kwargs[scale_path]
 
+            translation = hsVector3(pos[0] - (scale[0] - 1.0) / 2.0,
+                                    1.0 - pos[1] - (scale[1] - 1.0) / 2.0,
+                                    pos[2] - (scale[2] - 1.0) / 2.0)
             matrix = hsMatrix44()
-            matrix.setTranslate(hsVector3(*pos))
+            matrix.setTranslate(translation)
             matrix.setScale(hsVector3(*scale))
             return matrix
 

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -425,7 +425,10 @@ class MaterialConverter:
 
         # Transform
         xform = hsMatrix44()
-        xform.setTranslate(hsVector3(*slot.offset))
+        translation = hsVector3(slot.offset.x - (slot.scale.x - 1.0) / 2.0,
+                                1.0 - slot.offset.y - (slot.scale.y - 1.0) / 2.0,
+                                slot.offset.z - (slot.scale.z - 1.0) / 2.0)
+        xform.setTranslate(translation)
         xform.setScale(hsVector3(*slot.scale))
         layer.transform = xform
 

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -426,7 +426,7 @@ class MaterialConverter:
         # Transform
         xform = hsMatrix44()
         translation = hsVector3(slot.offset.x - (slot.scale.x - 1.0) / 2.0,
-                                1.0 - slot.offset.y - (slot.scale.y - 1.0) / 2.0,
+                                -slot.offset.y - (slot.scale.y - 1.0) / 2.0,
                                 slot.offset.z - (slot.scale.z - 1.0) / 2.0)
         xform.setTranslate(translation)
         xform.setScale(hsVector3(*slot.scale))


### PR DESCRIPTION
Blender's texture slot scaling is done from the center (0.5, 0.5) of the UV mapping viewport, with Y axis up. Plasma's scaling is done from origin (0, 0), with Y axis down. Ah, D3D and OpenGL...