### PR TITLE
Allow GroupMaster (MsgForwarder) to animate object data (such as lamps)

### DIFF
--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -119,13 +119,7 @@ class IDPropObjectMixin(IDPropMixin):
 
 
 def poll_animated_objects(self, value):
-    if value.animation_data is not None:
-        if value.animation_data.action is not None:
-            return True
-    if value.data is not None and value.data.animation_data is not None:
-        if value.data.animation_data.action is not None:
-            return True
-    return False
+    return value.plasma_object.has_animation_data
 
 def poll_camera_objects(self, value):
     return value.type == "CAMERA"

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -122,6 +122,9 @@ def poll_animated_objects(self, value):
     if value.animation_data is not None:
         if value.animation_data.action is not None:
             return True
+    if value.data is not None and value.data.animation_data is not None:
+        if value.data.animation_data.action is not None:
+            return True
     return False
 
 def poll_camera_objects(self, value):

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -193,7 +193,11 @@ class PlasmaAnimationGroupModifier(ActionModifier, PlasmaModifierProperties):
                 msg = "Animation Group '{}' specifies an invalid object. Ignoring..."
                 exporter.report.warn(msg, self.key_name, ident=2)
                 continue
-            if child_bo.animation_data is None or child_bo.animation_data.action is None:
+            animation_data = child_bo.animation_data
+            if animation_data is None or animation_data.action is None:
+                if child_bo.data is not None:
+                    animation_data = child_bo.data.animation_data
+            if animation_data is None or animation_data.action is None:
                 msg = "Animation Group '{}' specifies an object '{}' with no valid animation data. Ignoring..."
                 exporter.report.warn(msg, self.key_name, child_bo.name, indent=2)
                 continue

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -193,11 +193,7 @@ class PlasmaAnimationGroupModifier(ActionModifier, PlasmaModifierProperties):
                 msg = "Animation Group '{}' specifies an invalid object. Ignoring..."
                 exporter.report.warn(msg, self.key_name, ident=2)
                 continue
-            animation_data = child_bo.animation_data
-            if animation_data is None or animation_data.action is None:
-                if child_bo.data is not None:
-                    animation_data = child_bo.data.animation_data
-            if animation_data is None or animation_data.action is None:
+            if not child_bo.plasma_object.has_animation_data:
                 msg = "Animation Group '{}' specifies an object '{}' with no valid animation data. Ignoring..."
                 exporter.report.warn(msg, self.key_name, child_bo.name, indent=2)
                 continue


### PR DESCRIPTION
Pretty much what it says. The GroupMaster modifier expects to find animation data on the `object` itself and doesn't check the `object.data`, thus preventing you from adding an animated lamp to its list. This fixes that.