### PR TITLE
Fix emissive lightmaps broken by a203e10.

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -1263,7 +1263,12 @@ class MaterialConverter:
             state.shadeFlags |= hsGMatState.kShadeWhite
 
         if bm.emit:
-            state.shadeFlags |= hsGMatState.kShadeEmissive
+            # Lightmapped emissive layers seem to cause cascading render issues. Skip flagging it
+            # and just hope that the ambient color bump is good enough.
+            if bo.plasma_modifiers.lightmap.bake_lightmap:
+                self._report.warn("A lightmapped and emissive material??? You like living dangerously...", indent=3)
+            else:
+                state.shadeFlags |= hsGMatState.kShadeEmissive
 
         # Colors
         layer.ambient = self.get_material_ambient(bo, bm)

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -281,11 +281,10 @@ class MeshConverter(_MeshManager):
         if check_layer_shading_animation(base_layer):
             return False
 
-        # Reject emissive and shadeless because the kLiteMaterial equation has lots of options
-        # that are taken away by VtxNonPreshaded that are useful here.
+        # kShadeWhite (used for shadeless) is not handled for kLiteVtxNonPreshaded
         if material_idx is not None:
             bm = mesh.materials[material_idx]
-            if bm.emit or bm.use_shadeless:
+            if bm.use_shadeless:
                 return False
 
         mods = bo.plasma_modifiers


### PR DESCRIPTION
I'm not really sure what value an emissive lightmap has, but apparently people use them. So, it's better to give not-quite-so-emissive results instead of breaking the entire Age's rendering.