### PR TITLE
Add support for waveset buoys

### DIFF
--- a/korman/ui/modifiers/water.py
+++ b/korman/ui/modifiers/water.py
@@ -135,3 +135,19 @@ def water_shore(modifier, layout, context):
     col.prop(modifier, "finger")
     col.prop(modifier, "edge_opacity")
     col.prop(modifier, "edge_radius")
+
+
+class BuoyListUI(bpy.types.UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_property, index=0, flt_flag=0):
+        layout.prop(item, "display_name", emboss=False, text="", icon="MOD_CAST")
+
+
+def water_buoy(modifier, layout, context):
+    ui_list.draw_modifier_list(layout, "BuoyListUI", modifier, "buoys",
+                               "active_buoy_index", name_prefix="Buoy",
+                               name_prop="display_name", rows=2, maxrows=3)
+
+    # Display the active buoy
+    if modifier.buoys:
+        buoy = modifier.buoys[modifier.active_buoy_index]
+        layout.prop(buoy, "buoy_object", icon="MESH_DATA")


### PR DESCRIPTION
Adds a Buoy modifier that can be attached to a waveset. That modifier contains a list of objects that should float on top of the waveset.

![korman-buoys](https://user-images.githubusercontent.com/241708/121790840-8adae180-cb98-11eb-9c2e-73328606592c.png)

@Hoikas It seems to me like it would be best to have the list of buoys directly reference the objects, but everywhere else I see these sorts of lists in korman modifiers there's always a class in the middle (`PlasmaBuoyObject` in this case)