### PR TITLE
Alpha Vertex Blend Toggle

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -509,7 +509,10 @@ class MaterialConverter:
         else:
             layer_props = texture.plasma_layer
             layer.opacity = layer_props.opacity / 100
-            self._handle_layer_opacity(layer, layer_props.opacity)
+            if layer_props.opacity < 100 and not state.blendFlags & hsGMatState.kBlendMask:
+                state.blendFlags |= hsGMatState.kBlendAlpha
+            if layer_props.use_alpha_vcol:
+                state.blendFlags |= hsGMatState.kBlendAlpha
             if layer_props.alpha_halo:
                 state.blendFlags |= hsGMatState.kBlendAlphaTestHigh
             if layer_props.z_bias:

--- a/korman/properties/prop_texture.py
+++ b/korman/properties/prop_texture.py
@@ -38,6 +38,9 @@ class PlasmaLayer(bpy.types.PropertyGroup):
                                   description="Opacity of the texture",
                                   default=100.0, min=0.0, max=100.0,
                                   precision=0, subtype="PERCENTAGE")
+    use_alpha_vcol = BoolProperty(name="Use Alpha VCol",
+                                  description="Texture uses the Alpha vertex color values",
+                                  default=False)
     alpha_halo = BoolProperty(name="High Alpha Test",
                               description="Fixes halos seen around semitransparent objects resulting from sorting errors",
                               default=False)

--- a/korman/ui/ui_texture.py
+++ b/korman/ui/ui_texture.py
@@ -82,6 +82,7 @@ class PlasmaLayerPanel(TextureButtonsPanel, bpy.types.Panel):
         sub = col.column()
         sub.active = not use_stencil
         sub.prop(layer_props, "opacity", text="Opacity")
+        sub.prop(layer_props, "use_alpha_vcol", text="Use Alpha VCol")
         sub.separator()
         sub = col.column()
         sub.active = texture.type == "IMAGE" and texture.image is None


### PR DESCRIPTION
Adds a per-layer toggle just below the opacity slider to use the Alpha VCol values and blend the texture. Still needs sanity checks.