### PR TITLE
Persistent Baked Lighting

### DIFF
--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -56,6 +56,7 @@ class Exporter:
             self.image = image.ImageCache(self)
             self.locman = locman.LocalizationConverter(self)
             self.decal = decal.DecalConverter(self)
+            self.oven = etlight.LightBaker(self.report)
 
             # Step 0.8: Init the progress mgr
             self.mesh.add_progress_presteps(self.report)
@@ -126,10 +127,8 @@ class Exporter:
                 self.report.raise_errors()
 
     def _bake_static_lighting(self):
-        lighting_method = self._op.lighting_method
-        if lighting_method != "skip":
-            oven = etlight.LightBaker(self.report)
-            oven.bake_static_lighting(self._objects)
+        if self._op.lighting_method != "skip":
+            self.oven.bake_static_lighting(self._objects)
 
     def _collect_objects(self):
         scene = bpy.context.scene

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -14,10 +14,13 @@
 #    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
-from ..korlib import ConsoleToggler
+
 from pathlib import Path
+from contextlib import ExitStack
+
+from ..korlib import ConsoleToggler
+
 from PyHSPlasma import *
-import time
 
 from . import animation
 from . import camera
@@ -44,7 +47,7 @@ class Exporter:
 
     def run(self):
         log = logger.ExportVerboseLogger if self._op.verbose else logger.ExportProgressLogger
-        with ConsoleToggler(self._op.show_console), log(self._op.filepath) as self.report:
+        with ConsoleToggler(self._op.show_console), log(self._op.filepath) as self.report, ExitStack() as self.context_stack:
             # Step 0: Init export resmgr and stuff
             self.mgr = manager.ExportManager(self)
             self.mesh = mesh.MeshConverter(self)
@@ -56,7 +59,7 @@ class Exporter:
             self.image = image.ImageCache(self)
             self.locman = locman.LocalizationConverter(self)
             self.decal = decal.DecalConverter(self)
-            self.oven = etlight.LightBaker(self.report)
+            self.oven = etlight.LightBaker(self.report, stack=self.context_stack)
 
             # Step 0.8: Init the progress mgr
             self.mesh.add_progress_presteps(self.report)

--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -84,6 +84,7 @@ class LightBaker(_MeshManager):
             self._apply_render_settings(toggle, False)
             self._select_only(objs, toggle)
             bpy.ops.object.bake_image()
+            self._pack_lightmaps(objs)
 
     def _bake_vcols(self, objs, layers):
         with GoodNeighbor() as toggle:
@@ -108,8 +109,6 @@ class LightBaker(_MeshManager):
                 self._restore_uvtexs()
                 if not self.retain_lightmap_uvtex:
                     self._remove_stale_uvtexes(bake)
-                else:
-                    self._pack_lightmaps(bake)
             return result
 
     def _bake_static_lighting(self, bake, toggle):
@@ -283,9 +282,8 @@ class LightBaker(_MeshManager):
                     bake_vcol.append(i)
         return bake
 
-    def _pack_lightmaps(self, bake):
-        lightmap_iter = itertools.chain.from_iterable((value for key, value in bake.items() if key[0] == "lightmap"))
-        for bo in lightmap_iter:
+    def _pack_lightmaps(self, objs):
+        for bo in objs:
             im = self.get_lightmap(bo)
             if im is not None and im.is_dirty:
                 im.pack(as_png=True)

--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -43,6 +43,7 @@ class LightBaker(_MeshManager):
         self.lightmap_uvtex_name = "LIGHTMAPGEN"
         self.retain_lightmap_uvtex = True
         self.force = False
+        self._lightmap_images = {}
         self._uvtexs = {}
 
     def __del__(self):
@@ -213,6 +214,9 @@ class LightBaker(_MeshManager):
             material.light_group = dest
         return shouldibake
 
+    def get_lightmap(self, bo):
+        return self._lightmap_images.get(bo.name)
+
     def get_lightmap_name(self, bo):
         return self.lightmap_name.format(bo.name)
 
@@ -282,7 +286,7 @@ class LightBaker(_MeshManager):
     def _pack_lightmaps(self, bake):
         lightmap_iter = itertools.chain.from_iterable((value for key, value in bake.items() if key[0] == "lightmap"))
         for bo in lightmap_iter:
-            im = bpy.data.images.get(self.get_lightmap_name(bo))
+            im = self.get_lightmap(bo)
             if im is not None and im.is_dirty:
                 im.pack(as_png=True)
 
@@ -337,6 +341,7 @@ class LightBaker(_MeshManager):
             # Force delete and recreate the image because the size is out of date
             data_images.remove(im)
             im = data_images.new(im_name, width=size, height=size)
+        self._lightmap_images[bo.name] = im
 
         # If there is a cached LIGHTMAPGEN uvtexture, nuke it
         uvtex = uv_textures.get(self.lightmap_uvtex_name, None)

--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -254,11 +254,7 @@ class LightBaker(_MeshManager):
                 bake_pass = bake.setdefault(key, [])
                 bake_pass.append(i)
             elif mods.lighting.preshade:
-                vcols = i.data.vertex_colors
-                for j in _VERTEX_COLOR_LAYERS:
-                    if j in vcols:
-                        break
-                else:
+                if not any((vcol_layer.name.lower() in _VERTEX_COLOR_LAYERS for vcol_layer in i.data.vertex_colors)):
                     bake_vcol.append(i)
         return bake
 

--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -288,13 +288,6 @@ class LightBaker(_MeshManager):
             if im is not None and im.is_dirty:
                 im.pack(as_png=True)
 
-                # Blender bug? If there is no vertex color layer, some textured rendered objects
-                # seem to go KABLOOEY! So, make sure there is at least one dummy vcol layer.
-                vcols = bo.data.vertex_colors
-                if not bool(vcols):
-                    # So the user knows what's happening
-                    vcols.new("LIGHTMAPGEN_defeatcrash")
-
     def _pop_lightgroups(self):
         materials = bpy.data.materials
         for mat_name, lg in self._lightgroups.items():

--- a/korman/operators/op_lightmap.py
+++ b/korman/operators/op_lightmap.py
@@ -24,8 +24,6 @@ from ..helpers import UiHelper
 from ..korlib import ConsoleToggler
 
 class _LightingOperator:
-    _FINAL_VERTEX_COLOR_LAYER = "Col"
-
     @contextmanager
     def _oven(self, context):
         if context.scene.world is not None:
@@ -56,17 +54,9 @@ class LightmapAutobakePreviewOperator(_LightingOperator, bpy.types.Operator):
     def __init__(self):
         super().__init__()
 
-    def draw(self, context):
-        layout = self.layout
-
-        layout.label("This will overwrite the following vertex color layer:")
-        layout.label(self._FINAL_VERTEX_COLOR_LAYER, icon="GROUP_VCOL")
-
     def execute(self, context):
         with self._oven(context) as bake:
-            if self.final:
-                bake.vcol_layer_name = self._FINAL_VERTEX_COLOR_LAYER
-            else:
+            if not self.final:
                 bake.lightmap_name = "{}_LIGHTMAPGEN_PREVIEW.png"
                 bake.lightmap_uvtex_name = "LIGHTMAPGEN_PREVIEW"
             bake.force = self.final
@@ -91,14 +81,6 @@ class LightmapAutobakePreviewOperator(_LightingOperator, bpy.types.Operator):
 
         return {"FINISHED"}
 
-    def invoke(self, context, event):
-        # If this is a vertex color bake, we need to be sure that the user really
-        # wants to blow away any color layer they have.
-        if self.final and context.object.plasma_modifiers.lightmap.bake_type == "vcol":
-            if any((i.name == self._FINAL_VERTEX_COLOR_LAYER for i in context.object.data.vertex_colors)):
-                return context.window_manager.invoke_props_dialog(self)
-        return self.execute(context)
-
 
 class LightmapBakeMultiOperator(_LightingOperator, bpy.types.Operator):
     bl_idname = "object.plasma_lightmap_bake"
@@ -118,7 +100,6 @@ class LightmapBakeMultiOperator(_LightingOperator, bpy.types.Operator):
 
         with self._oven(context) as bake:
             bake.force = True
-            bake.vcol_layer_name = self._FINAL_VERTEX_COLOR_LAYER
             if not bake.bake_static_lighting(filtered_objects):
                 self.report({"WARNING"}, "Nothing was baked.")
                 return {"FINISHED"}
@@ -149,44 +130,18 @@ class LightmapClearMultiOperator(_LightingOperator, bpy.types.Operator):
     def _iter_vcols(self, objects):
         yield from filter(lambda x: x.type == "MESH" and not x.plasma_modifiers.lightmap.bake_lightmap, objects)
 
-    def _iter_final_vcols(self, objects):
-        yield from filter(lambda x: x.data.vertex_colors.get(self._FINAL_VERTEX_COLOR_LAYER), self._iter_vcols(objects))
-
-    def draw(self, context):
-        layout = self.layout
-
-        layout.label("This will remove the vertex color layer '{}' on:".format(self._FINAL_VERTEX_COLOR_LAYER))
-        col = layout.column_flow()
-
-        _MAX_OBJECTS = 50
-        vcol_iter = enumerate(self._iter_final_vcols(self._get_objects(context)))
-        for _, bo in itertools.takewhile(lambda x: x[0] < _MAX_OBJECTS, vcol_iter):
-            col.label(bo.name, icon="OBJECT_DATA")
-        remainder = sum((1 for _, _ in vcol_iter))
-        if remainder:
-            layout.label("... and {} other objects.".format(remainder))
-
-    def _get_objects(self, context):
-        return context.selected_objects if self.clear_selection else context.scene.objects
-
     def execute(self, context):
-        all_objects = self._get_objects(context)
+        all_objects = context.selected_objects if self.clear_selection else context.scene.objects
 
         for i in self._iter_lightmaps(all_objects):
             i.plasma_modifiers.lightmap.image = None
 
         for i in self._iter_vcols(all_objects):
             vcols = i.data.vertex_colors
-            col_layer = vcols.get(self._FINAL_VERTEX_COLOR_LAYER)
+            col_layer = vcols.get("autocolor")
             if col_layer is not None:
                 vcols.remove(col_layer)
         return {"FINISHED"}
-
-    def invoke(self, context, event):
-        all_objects = self._get_objects(context)
-        if any(self._iter_final_vcols(all_objects)):
-            return context.window_manager.invoke_props_dialog(self)
-        return self.execute(context)
 
 
 @bpy.app.handlers.persistent
@@ -204,9 +159,6 @@ def _toss_garbage(scene):
         uvtex = i.uv_textures.get("LIGHTMAPGEN_PREVIEW")
         if uvtex is not None:
             i.uv_textures.remove(uvtex)
-        vcol_layer = i.vertex_colors.get("autocolor")
-        if vcol_layer is not None:
-            i.vertex_colors.remove(vcol_layer)
 
 # collects light baking garbage
 bpy.app.handlers.save_pre.append(_toss_garbage)

--- a/korman/operators/op_lightmap.py
+++ b/korman/operators/op_lightmap.py
@@ -81,7 +81,7 @@ class LightmapAutobakePreviewOperator(_LightingOperator, bpy.types.Operator):
             if tex is None:
                 tex = bpy.data.textures.new("LIGHTMAPGEN_PREVIEW", "IMAGE")
             tex.extension = "CLIP"
-            image = bpy.data.images[bake.get_lightmap_name(context.object)]
+            image = bake.get_lightmap(context.object)
             tex.image = image
             if self.final:
                 lightmap_mod.image = image
@@ -126,7 +126,7 @@ class LightmapBakeMultiOperator(_LightingOperator, bpy.types.Operator):
         for i in filtered_objects:
             lightmap_mod = i.plasma_modifiers.lightmap
             if lightmap_mod.bake_lightmap:
-                lightmap_mod.image = bpy.data.images[bake.get_lightmap_name(i)]
+                lightmap_mod.image = bake.get_lightmap(i)
 
         return {"FINISHED"}
 

--- a/korman/operators/op_lightmap.py
+++ b/korman/operators/op_lightmap.py
@@ -16,10 +16,25 @@
 import bpy
 from bpy.props import *
 
+from contextlib import contextmanager
+
 from ..exporter.etlight import LightBaker
 from ..helpers import UiHelper
+from ..korlib import ConsoleToggler
 
 class _LightingOperator:
+    _FINAL_VERTEX_COLOR_LAYER = "Col"
+
+    @contextmanager
+    def _oven(self, context):
+        if context.scene.world is not None:
+            verbose = context.scene.world.plasma_age.verbose
+            console = context.scene.world.plasma_age.show_console
+        else:
+            verbose = False
+            console = True
+        with UiHelper(context), ConsoleToggler(console), LightBaker(verbose=verbose) as oven:
+            yield oven
 
     @classmethod
     def poll(cls, context):
@@ -32,26 +47,133 @@ class _LightingOperator:
 class LightmapAutobakePreviewOperator(_LightingOperator, bpy.types.Operator):
     bl_idname = "object.plasma_lightmap_preview"
     bl_label = "Preview Lightmap"
+    bl_description = "Preview Lighting"
     bl_options = {"INTERNAL"}
+
+    final = BoolProperty(name="Use this lightmap for export")
+
+    def __init__(self):
+        super().__init__()
+
+    def draw(self, context):
+        layout = self.layout
+
+        layout.label("This will overwrite the following vertex color layer:")
+        layout.label(self._FINAL_VERTEX_COLOR_LAYER, icon="GROUP_VCOL")
+
+    def execute(self, context):
+        with self._oven(context) as bake:
+            if self.final:
+                bake.vcol_layer_name = self._FINAL_VERTEX_COLOR_LAYER
+            else:
+                bake.lightmap_name = "{}_LIGHTMAPGEN_PREVIEW.png"
+                bake.lightmap_uvtex_name = "LIGHTMAPGEN_PREVIEW"
+            bake.force = self.final
+            bake.retain_lightmap_uvtex = self.final
+            if not bake.bake_static_lighting([context.object,]):
+                self.report({"WARNING"}, "No valid lights found to bake.")
+                return {"FINISHED"}
+
+        lightmap_mod = context.object.plasma_modifiers.lightmap
+        if lightmap_mod.bake_lightmap:
+            tex = bpy.data.textures.get("LIGHTMAPGEN_PREVIEW")
+            if tex is None:
+                tex = bpy.data.textures.new("LIGHTMAPGEN_PREVIEW", "IMAGE")
+            tex.extension = "CLIP"
+            image = bpy.data.images[bake.get_lightmap_name(context.object)]
+            tex.image = image
+            if self.final:
+                lightmap_mod.image = image
+        else:
+            for i in context.object.data.vertex_colors:
+                i.active = i.name == bake.vcol_layer_name
+
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        # If this is a vertex color bake, we need to be sure that the user really
+        # wants to blow away any color layer they have.
+        if self.final and context.object.plasma_modifiers.lightmap.bake_type == "vcol":
+            if any((i.name == self._FINAL_VERTEX_COLOR_LAYER for i in context.object.data.vertex_colors)):
+                return context.window_manager.invoke_props_dialog(self)
+        return self.execute(context)
+
+
+class LightmapBakeMultiOperator(_LightingOperator, bpy.types.Operator):
+    bl_idname = "object.plasma_lightmap_bake"
+    bl_label = "Bake Lighting"
+    bl_description = "Bake scene lighting to object(s)"
+
+    bake_selection = BoolProperty(name="Bake Selection",
+                                  description="Bake only the selected objects (else all objects)",
+                                  options=set())
 
     def __init__(self):
         super().__init__()
 
     def execute(self, context):
-        with UiHelper(context):
-            with LightBaker() as bake:
-                if not bake.bake_static_lighting([context.active_object,]):
-                    self.report({"INFO"}, "No valid lights found to bake.")
-                    return {"FINISHED"}
+        all_objects = context.selected_objects if self.bake_selection else context.scene.objects
+        filtered_objects = [i for i in all_objects if i.type == "MESH" and i.plasma_object.enabled]
 
-        if context.object.plasma_modifiers.lightmap.bake_type == "lightmap":
-            tex = bpy.data.textures.get("LIGHTMAPGEN_PREVIEW")
-            if tex is None:
-                tex = bpy.data.textures.new("LIGHTMAPGEN_PREVIEW", "IMAGE")
-            tex.extension = "CLIP"
-            tex.image = bpy.data.images["{}_LIGHTMAPGEN.png".format(context.active_object.name)]
-        else:
-            for i in context.object.data.vertex_colors:
-                i.active = i.name == "autocolor"
+        with self._oven(context) as bake:
+            bake.force = True
+            bake.vcol_layer_name = self._FINAL_VERTEX_COLOR_LAYER
+            if not bake.bake_static_lighting(filtered_objects):
+                self.report({"WARNING"}, "Nothing was baked.")
+                return {"FINISHED"}
+
+        for i in filtered_objects:
+            lightmap_mod = i.plasma_modifiers.lightmap
+            if lightmap_mod.bake_lightmap:
+                lightmap_mod.image = bpy.data.images[bake.get_lightmap_name(i)]
 
         return {"FINISHED"}
+
+
+class LightmapClearMultiOperator(_LightingOperator, bpy.types.Operator):
+    bl_idname = "object.plasma_lightmap_clear"
+    bl_label = "Clear Lighting"
+    bl_description = "Clear baked lighting"
+
+    clear_selection = BoolProperty(name="Clear Selection",
+                                   description="Clear only the selected objects (else all objects)",
+                                   options=set())
+
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, context):
+        all_objects = context.selected_objects if self.clear_selection else context.scene.objects
+        for i in filter(lambda x: x.type == "MESH", all_objects):
+            lightmap_mod = i.plasma_modifiers.lightmap
+            if lightmap_mod.bake_lightmap:
+                lightmap_mod.image = None
+            else:
+                vcols = i.data.vertex_colors
+                col_layer = vcols.get(self._FINAL_VERTEX_COLOR_LAYER)
+                if col_layer is not None:
+                    vcols.remove(col_layer)
+        return {"FINISHED"}
+
+
+@bpy.app.handlers.persistent
+def _toss_garbage(scene):
+    """Removes all LIGHTMAPGEN and autocolor garbage before saving"""
+    bpy_data = bpy.data
+    tex = bpy_data.textures.get("LIGHTMAPGEN_PREVIEW")
+    if tex is not None:
+        bpy_data.textures.remove(tex)
+
+    for i in bpy_data.images:
+        if i.name.endswith("_LIGHTMAPGEN_PREVIEW.png"):
+            bpy_data.images.remove(i)
+    for i in bpy_data.meshes:
+        uvtex = i.uv_textures.get("LIGHTMAPGEN_PREVIEW")
+        if uvtex is not None:
+            i.uv_textures.remove(uvtex)
+        vcol_layer = i.vertex_colors.get("autocolor")
+        if vcol_layer is not None:
+            i.vertex_colors.remove(vcol_layer)
+
+# collects light baking garbage
+bpy.app.handlers.save_pre.append(_toss_garbage)

--- a/korman/operators/op_lightmap.py
+++ b/korman/operators/op_lightmap.py
@@ -44,10 +44,14 @@ class LightmapAutobakePreviewOperator(_LightingOperator, bpy.types.Operator):
                     self.report({"INFO"}, "No valid lights found to bake.")
                     return {"FINISHED"}
 
-        tex = bpy.data.textures.get("LIGHTMAPGEN_PREVIEW")
-        if tex is None:
-            tex = bpy.data.textures.new("LIGHTMAPGEN_PREVIEW", "IMAGE")
-        tex.extension = "CLIP"
-        tex.image = bpy.data.images["{}_LIGHTMAPGEN.png".format(context.active_object.name)]
+        if context.object.plasma_modifiers.lightmap.bake_type == "lightmap":
+            tex = bpy.data.textures.get("LIGHTMAPGEN_PREVIEW")
+            if tex is None:
+                tex = bpy.data.textures.new("LIGHTMAPGEN_PREVIEW", "IMAGE")
+            tex.extension = "CLIP"
+            tex.image = bpy.data.images["{}_LIGHTMAPGEN.png".format(context.active_object.name)]
+        else:
+            for i in context.object.data.vertex_colors:
+                i.active = i.name == "autocolor"
 
         return {"FINISHED"}

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -463,14 +463,9 @@ class PlasmaLightMapGen(idprops.IDPropMixin, PlasmaModifierProperties, PlasmaMod
         if not self.bake_lightmap:
             return
 
-        if self.image is not None:
-            lightmap_im = self.image
-        else:
-            # Gulp...
-            lightmap_im = bpy.data.images.get("{}_LIGHTMAPGEN.png".format(bo.name))
-
         # If no lightmap image is found, then either lightmap generation failed (error raised by oven)
         # or baking is turned off. Either way, bail out.
+        lightmap_im = self.image if self.image is not None else exporter.oven.get_lightmap(bo)
         if lightmap_im is None:
             return
         mat_mgr = exporter.mesh.material

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -196,13 +196,17 @@ def lightmap(modifier, layout, context):
     col = layout.column()
     col.active = is_texture
     col.prop_search(modifier, "uv_map", context.active_object.data, "uv_textures")
+    col = layout.column()
+    col.active = is_texture
+    col.prop(modifier, "image", icon="IMAGE_RGB")
 
     # Lightmaps can only be applied to objects with opaque materials.
     if is_texture and any((i.use_transparency for i in modifier.id_data.data.materials if i is not None)):
         layout.label("Transparent objects cannot be lightmapped.", icon="ERROR")
     else:
-        col = layout.column()
-        col.operator("object.plasma_lightmap_preview", "Preview Lightmap" if is_texture else "Preview Vertex Colors", icon="RENDER_STILL")
+        row = layout.row(align=True)
+        row.operator("object.plasma_lightmap_preview", "Preview", icon="RENDER_STILL").final = False
+        row.operator("object.plasma_lightmap_preview", "Bake for Export", icon="RENDER_STILL").final = True
 
         # Kind of clever stuff to show the user a preview...
         # We can't show images, so we make a hidden ImageTexture called LIGHTMAPGEN_PREVIEW. We check
@@ -211,7 +215,7 @@ def lightmap(modifier, layout, context):
         if is_texture:
             tex = bpy.data.textures.get("LIGHTMAPGEN_PREVIEW")
             if tex is not None and tex.image is not None:
-                im_name = "{}_LIGHTMAPGEN.png".format(context.active_object.name)
+                im_name = "{}_LIGHTMAPGEN_PREVIEW.png".format(context.active_object.name)
                 if tex.image.name == im_name:
                     layout.template_preview(tex, show_buttons=False)
 

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -202,18 +202,18 @@ def lightmap(modifier, layout, context):
         layout.label("Transparent objects cannot be lightmapped.", icon="ERROR")
     else:
         col = layout.column()
-        col.active = is_texture
-        operator = col.operator("object.plasma_lightmap_preview", "Preview Lightmap", icon="RENDER_STILL")
+        col.operator("object.plasma_lightmap_preview", "Preview Lightmap" if is_texture else "Preview Vertex Colors", icon="RENDER_STILL")
 
         # Kind of clever stuff to show the user a preview...
         # We can't show images, so we make a hidden ImageTexture called LIGHTMAPGEN_PREVIEW. We check
         # the backing image name to see if it's for this lightmap. If so, you have a preview. If not,
         # well... It was nice knowing you!
-        tex = bpy.data.textures.get("LIGHTMAPGEN_PREVIEW")
-        if tex is not None and tex.image is not None:
-            im_name = "{}_LIGHTMAPGEN.png".format(context.active_object.name)
-            if tex.image.name == im_name:
-                layout.template_preview(tex, show_buttons=False)
+        if is_texture:
+            tex = bpy.data.textures.get("LIGHTMAPGEN_PREVIEW")
+            if tex is not None and tex.image is not None:
+                im_name = "{}_LIGHTMAPGEN.png".format(context.active_object.name)
+                if tex.image.name == im_name:
+                    layout.template_preview(tex, show_buttons=False)
 
 def rtshadow(modifier, layout, context):
     split = layout.split()

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -205,8 +205,11 @@ def lightmap(modifier, layout, context):
         layout.label("Transparent objects cannot be lightmapped.", icon="ERROR")
     else:
         row = layout.row(align=True)
-        row.operator("object.plasma_lightmap_preview", "Preview", icon="RENDER_STILL").final = False
-        row.operator("object.plasma_lightmap_preview", "Bake for Export", icon="RENDER_STILL").final = True
+        if modifier.bake_lightmap:
+            row.operator("object.plasma_lightmap_preview", "Preview", icon="RENDER_STILL").final = False
+            row.operator("object.plasma_lightmap_preview", "Bake for Export", icon="RENDER_STILL").final = True
+        else:
+            row.operator("object.plasma_lightmap_preview", "Bake", icon="RENDER_STILL").final = True
 
         # Kind of clever stuff to show the user a preview...
         # We can't show images, so we make a hidden ImageTexture called LIGHTMAPGEN_PREVIEW. We check

--- a/korman/ui/ui_toolbox.py
+++ b/korman/ui/ui_toolbox.py
@@ -45,7 +45,13 @@ class PlasmaToolboxPanel(ToolboxPanel, bpy.types.Panel):
         col.label("Plasma Pages:")
         col.operator("object.plasma_move_selection_to_page", icon="BOOKMARKS", text="Move to Page")
         col.operator("object.plasma_select_page_objects", icon="RESTRICT_SELECT_OFF", text="Select Objects")
-        
+
+        col.label("Lighting:")
+        col.operator("object.plasma_lightmap_bake", icon="RENDER_STILL", text="Bake All").bake_selection = False
+        col.operator("object.plasma_lightmap_bake", icon="RENDER_REGION", text="Bake Selection").bake_selection = True
+        col.operator("object.plasma_lightmap_clear", icon="X", text="Clear All").clear_selection = False
+        col.operator("object.plasma_lightmap_clear", icon="X", text="Clear Selection").clear_selection = True
+
         col.label("Package Sounds:")
         col.operator("object.plasma_toggle_sound_export", icon="MUTE_IPO_OFF", text="Enable All").enable = True
         all_sounds_export = all((i.package for i in itertools.chain.from_iterable(i.plasma_modifiers.soundemit.sounds for i in bpy.context.selected_objects if i.plasma_modifiers.soundemit.enabled)))


### PR DESCRIPTION
This changeset allows reusing the same baked lighting from one export to another. This is an opt-in feature for when your Age becomes lighting heavy and the performance penalty becomes expensive when trying to iterate on other aspects of the Age.

New operators have been added. In the toolbox, you can "Bake All" or "Bake Selected" lighting at any time. In the lightmap modifier, you can "Bake for Export". These buttons bake vertex colors to the "Col" layer or set the new "Image" field on the lightmap modifier, as appropriate. On export, if a "Col" or image texture is found, it is used instead of lighting being rebaked. This means that if the lighting changes on those objects YOU have to rebake them using these same features. To return to the previous functionality of rebake every export, the toolbox operators "Clear All" or "Clear Selection" may be used. Alternatively, remove the image from the lightmap modifier or delete the Col vertex color layer.