### PR TITLE
Add Back Exp2 Fog

### DIFF
--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -331,6 +331,8 @@ class ExportManager:
                     stream.writeLine("Graphics.Renderer.Fog.SetDefLinear {:.2f} {:.2f} {:.2f}".format(fni.fog_start, fni.fog_end, fni.fog_density))
                 elif fni.fog_method == "exp":
                     stream.writeLine("Graphics.Renderer.Fog.SetDefExp {:.2f} {:.2f}".format(fni.fog_end, fni.fog_density))
+                elif fni.fog_method == "exp2":
+                    stream.writeLine("Graphics.Renderer.Fog.SetDefExp2 {:.2f} {:.2f}".format(fni.fog_end, fni.fog_density))
 
     def _write_pages(self):
         age_name = self._age_info.name

--- a/korman/properties/prop_world.py
+++ b/korman/properties/prop_world.py
@@ -30,9 +30,9 @@ class PlasmaFni(bpy.types.PropertyGroup):
                                     subtype="COLOR")
     fog_method = EnumProperty(name="Fog Type",
                               items=[
-                                     ("linear", "Linear", "Linear Fog"),
-                                     ("exp", "Exponential", "Exponential Fog"),
-                                     ("exp2", "Exponential 2", "Exponential Fog 2"),
+                                     ("linear", "Linear", "Fog Based on Linear Distance"),
+                                     ("exp", "Exponential", "Fog Based on Exponential Distance"),
+                                     ("exp2", "Exponential 2", "Fog Based on Exponential Distance Squared"),
                                      ("none", "None", "No Fog")
                                     ])
     fog_start = FloatProperty(name="Start",

--- a/korman/properties/prop_world.py
+++ b/korman/properties/prop_world.py
@@ -32,7 +32,8 @@ class PlasmaFni(bpy.types.PropertyGroup):
                               items=[
                                      ("linear", "Linear", "Linear Fog"),
                                      ("exp", "Exponential", "Exponential Fog"),
-                                     ("none", "None", "Use fog from the previous age")
+                                     ("exp2", "Exponential 2", "Exponential Fog 2"),
+                                     ("none", "None", "No Fog")
                                     ])
     fog_start = FloatProperty(name="Start",
                               description="",


### PR DESCRIPTION
Reintroduces the Exp2 Fog option for completion and ZLZ importation reasons and also updates the "none" fog function description.