### PR TITLE
Warn if more than 8 RT lamps are on a material.

### DIFF
--- a/korman/exporter/rtlight.py
+++ b/korman/exporter/rtlight.py
@@ -258,6 +258,7 @@ class LightConverter:
         # If there is no light group, we'll say that there is no runtime lighting...
         # If there is, we will harvest all Blender lamps in that light group that are Plasma Objects
         lg = bm.light_group
+        lcount = 0
         if lg is not None:
             for obj in lg.objects:
                 if obj.type != "LAMP":
@@ -291,6 +292,10 @@ class LightConverter:
                 else:
                     self._report.msg("[{}] PermaLight '{}'", lamp.type, obj.name, indent=2)
                     permaLights.append(pl_light)
+                    lcount = lcount + 1
+    
+        if lcount > 8:
+            self._report.warn("More than 8 RT lamps on material: '{}'".format(bm.name), indent=1)
 
         return (permaLights, permaProjs)
 

--- a/korman/exporter/rtlight.py
+++ b/korman/exporter/rtlight.py
@@ -292,10 +292,9 @@ class LightConverter:
                 else:
                     self._report.msg("[{}] PermaLight '{}'", lamp.type, obj.name, indent=2)
                     permaLights.append(pl_light)
-                    lcount = lcount + 1
-    
-        if lcount > 8:
-            self._report.warn("More than 8 RT lamps on material: '{}'".format(bm.name), indent=1)
+
+        if len(permaLights) > 8:
+            self._report.warn("More than 8 RT lamps on material: '{}'", bm.name, indent=1)
 
         return (permaLights, permaProjs)
 

--- a/korman/exporter/rtlight.py
+++ b/korman/exporter/rtlight.py
@@ -258,7 +258,6 @@ class LightConverter:
         # If there is no light group, we'll say that there is no runtime lighting...
         # If there is, we will harvest all Blender lamps in that light group that are Plasma Objects
         lg = bm.light_group
-        lcount = 0
         if lg is not None:
             for obj in lg.objects:
                 if obj.type != "LAMP":


### PR DESCRIPTION
I'm probably late to the party, but I have found that PotS can't handle more than 8 RT lamps on one material. This might vary by target engine, though, so no failure pronouncement is made.