### PR TITLE
Clearly deliniate the circles of hell.

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -198,7 +198,13 @@ class MaterialConverter:
             hgmat = None
         else:
             # Ensure that RT-lit objects don't infect the static-lit objects.
-            mat_prefix = "RTLit_" if bo.plasma_modifiers.lighting.rt_lights else ""
+            lighting_mod = bo.plasma_modifiers.lighting
+            if lighting_mod.unleashed:
+                mat_prefix = "Unleashed_"
+            elif lighting_mod.rt_lights:
+                mat_prefix = "RTLit_"
+            else:
+                mat_prefix = ""
             mat_name = "".join((mat_prefix, bm.name))
             self._report.msg("Exporting Material '{}'", mat_name, indent=1)
             hsgmat = self._mgr.find_key(hsGMaterial, name=mat_name, bl=bo)

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -590,6 +590,11 @@ class PlasmaLightingMod(PlasmaModifierProperties):
         return (self.enabled and self.force_rt_lights) or self.want_rt_lights
 
     @property
+    def unleashed(self):
+        """Has Satan been unleashed? Meaning, RT lights and preshading."""
+        return self.enabled and self.rt_lights and self.preshade
+
+    @property
     def want_rt_lights(self):
         """Gets whether or not this object ought to be lit dynamically"""
         mods = self.id_data.plasma_modifiers

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -153,28 +153,26 @@ def lighting(modifier, layout, context):
 
     lightmap = modifier.id_data.plasma_modifiers.lightmap
     have_static_lights = lightmap.enabled or modifier.preshade
-    def yes_no(val):
-        return "Yes" if val else "No"
 
     col = layout.column(align=True)
     col.label("Plasma Lighting Summary:")
-    if modifier.rt_lights and have_static_lights:
-        col.label(" You have unleashed Satan!", icon="GHOST_ENABLED")
+    if modifier.unleashed:
+        col.label("You have unleashed Satan!", icon="GHOST_ENABLED")
     else:
-        col.label(" Satan remains ensconced deep in the abyss...", icon="GHOST_ENABLED")
+        col.label("Satan remains ensconced deep in the abyss...", icon="GHOST_ENABLED")
     col.label("Animated lights will be cast at runtime.", icon="LAYER_USED")
     col.label("Projection lights will be cast at runtime.", icon="LAYER_USED")
     col.label("Specular lights will be cast to specular materials at runtime.", icon="LAYER_USED")
     col.label("Other Plasma lights {} be cast at runtime.".format("will" if modifier.rt_lights else "will NOT"),
               icon="LAYER_USED")
 
-    map_type = "a lightmap" if lightmap.enabled and lightmap.bake_type == "lightmap" else "vertex colors"
+    map_type = "a lightmap" if lightmap.bake_lightmap else "vertex colors"
     if lightmap.enabled and lightmap.lights:
             col.label("All '{}' lights will be baked to {}".format(lightmap.lights.name, map_type),
                       icon="LAYER_USED")
     elif have_static_lights:
         light_type = "Blender-only" if modifier.rt_lights else "unanimated"
-        col.label("Other {} lights will be baked to {}.".format(light_type, map_type), icon="LAYER_USED")
+        col.label("Other {} lights will be baked to {} (if applicable).".format(light_type, map_type), icon="LAYER_USED")
     else:
         col.label("No static lights will be baked.", icon="LAYER_USED")
 


### PR DESCRIPTION
If we've unleashed Satan on a material, he will perform his dark magick on the material colors. Therefore, we need to prefix the satanic materials with something other than "RTLit_" lest the plain old runtime lit materials be subjugated by the prince of darkness.

Fixes #240