### PR TITLE
Don't mark lights in a group as `kLPMovable`.

### DIFF
--- a/korman/exporter/rtlight.py
+++ b/korman/exporter/rtlight.py
@@ -193,7 +193,7 @@ class LightConverter:
 
         # If the lamp has any sort of animation attached, then it needs to be marked movable.
         # Otherwise, Plasma may not use it for lighting.
-        if bo.plasma_object.has_animation_data:
+        if bo.plasma_object.has_animation_data and not has_lg:
             pl_light.setProperty(plLightInfo.kLPMovable, True)
 
         # *Sigh*


### PR DESCRIPTION
It looks like simply attaching a lamp to a group already has fairly major implications for how it's exported. If you're adding a lamp into a group, then you are basically saying, "I only want to affect these specific objects.", so marking them as movable (meaning, "apply me to all objects") doesn't really make sense in that context.

Fixes #264
CC @DoobesURU 