### PR TITLE
Code that kills opacity animations

### DIFF
--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -296,7 +296,8 @@ class PlasmaAnimCmdMsgNode(idprops.IDPropMixin, PlasmaMessageWithCallbacksNode, 
                 self.raise_error("At least one of: target object, material, texture MUST be specified")
             target = exporter.mesh.material.get_texture_animation_key(obj, material, texture, self.anim_name)
 
-        target = [i for i in target if not isinstance(i.object, (plAgeGlobalAnim, plLayerSDLAnimation))]
+        # this kills opacity animation:
+        # target = [i for i in target if not isinstance(i.object, (plAgeGlobalAnim, plLayerSDLAnimation))]
         if not target:
             self.raise_error("No controllable animations were found.")
         for i in target:


### PR DESCRIPTION
Just noting code that kills opacity animations, triggering message, "No controllable animations were found." I'm guessing that just removing the code isn't the answer, though doing so restores opacity animations without obvious harm in my limited testing (Flying Cauldron). I don't know how to figure this one out, unfortunately.

Per ametist, note that this impacts Tiam.