### PR TITLE
Add Custom GUI Dialog Modifier

### DIFF
--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -27,6 +27,8 @@ from ..plasma_magic import *
 # NOTE: We are using Factory indices because I doubt all of these classes are implemented.
 _pool_types = (
     plFactory.ClassIndex("plPostEffectMod"),
+    plFactory.ClassIndex("plSingleModifier"),
+    plFactory.ClassIndex("pfGUIControlMod"),
     plFactory.ClassIndex("pfGUIDialogMod"),
     plFactory.ClassIndex("pfGUIButtonMod"),
     plFactory.ClassIndex("plMsgForwarder"),

--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -28,6 +28,7 @@ from ..plasma_magic import *
 _pool_types = (
     plFactory.ClassIndex("plPostEffectMod"),
     plFactory.ClassIndex("pfGUIDialogMod"),
+    plFactory.ClassIndex("pfGUIButtonMod"),
     plFactory.ClassIndex("plMsgForwarder"),
     plFactory.ClassIndex("plClothingItem"),
     plFactory.ClassIndex("plArmatureEffectFootSound"),

--- a/korman/properties/modifiers/gui.py
+++ b/korman/properties/modifiers/gui.py
@@ -86,6 +86,56 @@ class ImageLibraryItem(bpy.types.PropertyGroup):
                                      options=set())
 
 
+class PlasmaGUIDialogModifier(PlasmaModifierProperties):
+    pl_id = "guidialogmod"
+    
+    bl_category = "GUI"
+    bl_label = "GUI Dialog"
+    bl_description = "Brings up a custom GUI dialog"
+    bl_icon = "VIEWZOOM"
+
+    versions = EnumProperty(name="Export Targets",
+                            description="Plasma versions for which this journal exports",
+                            items=game_versions,
+                            options={"ENUM_FLAG"},
+                            default={"pvMoul", "pvPots", "pvPrime"})
+    
+    clickable = PointerProperty(name="GUI Clickable",
+                               description="Object to click to initiate GUI",
+                               type=bpy.types.Object,
+                               poll=idprops.poll_mesh_objects,
+                               options=set())
+    region = PointerProperty(name="GUI Click Region",
+                                description="GUI clickable region",
+                                type=bpy.types.Object,
+                                poll=idprops.poll_mesh_objects,
+                                options=set())
+    gui_object = PointerProperty(name="GUI Object",
+                                description="Object that will be viewed when GUI is active",
+                                type=bpy.types.Object,
+                                poll=idprops.poll_mesh_objects,
+                                options=set())
+    button = PointerProperty(name="GUI Button",
+                                description="Object to click to deactivate GUI (optional)",
+                                type=bpy.types.Object,
+                                poll=idprops.poll_mesh_objects,
+                                options=set())
+    
+    def sanity_check(self):
+        if self.gui_object is None:
+            raise ExportError("{}: GUI Dialog modifier requires a GUI Object!", self.id_data.name)
+        elif self.click is None:
+            raise ExportError("{}: GUI Dialog modifier requires a clickable!", self.id_data.name)
+
+    def pre_export(self, exporter, bo):
+        our_versions = (globals()[j] for j in self.versions)
+        version = exporter.mgr.getVer()
+        if version not in our_versions:
+            exporter.report.port("Object '{}' has a GUI Dialog not enabled for export to the selected engine.  Skipping.",
+                                 bo.name, version, indent=2)
+            return
+
+
 class PlasmaImageLibraryModifier(PlasmaModifierProperties):
     pl_id = "imagelibmod"
 

--- a/korman/properties/modifiers/gui.py
+++ b/korman/properties/modifiers/gui.py
@@ -163,19 +163,19 @@ class PlasmaGUIDialogModifier(PlasmaModifierProperties):
 
     def export(self, exporter, bo):
         # create post effect mod
-        guiposteffect = exporter.mgr.find_create_object(plPostEffectMod, bl=bo)
+        guiposteffect = exporter.mgr.find_create_object(plPostEffectMod, "{}_PostEffectMod".format(self.key_name))
         guiposteffect.hither = plPostEffectMod.GetHither("0.5")
         guiposteffect.yon = plPostEffectMod.GetYon("1000")
         guiposteffect.fov_x = plPostEffectMod.GetFovX("45")
         guiposteffect.fov_y = plPostEffectMod.GetFovY("33.75")
         # create GUI Dialog
-        guidialog = exporter.mgr.find_create_object(pfGUIDialogMod, bl=bo)
+        guidialog = exporter.mgr.find_create_object(pfGUIDialogMod, "{}_GUIDialogMod".format(self.key_name))
         guidialog.mode |= pfGUIDialogMod.kModal
         guidialog.posteffect = pfGUIDialogMod.GetRenderMod(guiposteffect)
         guidialog.sceneNode = exporter.mgr.get_scene_node(so.key.location)
         # do we have a clickoff button?
         if self.gui_button:
-            buttonmod = exporter.mgr.find_create_object(pfGUIButtonMod, bl=bo)
+            buttonmod = exporter.mgr.find_create_object(pfGUIButtonMod, "{}_GUIButtonMod".format(self.key_name))
             buttonmod.flags = pfGUIButtonMod.kWantsInterest | pfGUIButtonMod.kInheritProcFromDlg
             buttonmod.tagid = pfGUIButtonMod.GetTagID("99")
             guidialog.button = pfGUIDialogMod.GetControlFromTag(buttonmod)

--- a/korman/ui/modifiers/gui.py
+++ b/korman/ui/modifiers/gui.py
@@ -37,13 +37,13 @@ def guidialogmod(modifier, layout, context):
     layout.label("GUI Objects:")
     main_col.label("Required:")
     col = main_col.column()
-    col.prop(modifier, "clickable", text="Clickable")
+    col.prop(modifier, "gui_clickable", text="Clickable")
     col.prop(modifier, "gui_object", text="GUI Object")
     main_col.separator()
     main_col.label("Optional:")
     col = main_col.column(align=True)
-    col.prop(modifier, "region", text="Click Region")
-    col.prop(modifier, "button", text="GUI Button")
+    col.prop(modifier, "gui_region", text="Click Region")
+    col.prop(modifier, "gui_button", text="GUI Button")
 
 def imagelibmod(modifier, layout, context):
     ui_list.draw_modifier_list(layout, "ImageListUI", modifier, "images", "active_image_index", rows=3, maxrows=6)

--- a/korman/ui/modifiers/gui.py
+++ b/korman/ui/modifiers/gui.py
@@ -29,12 +29,10 @@ class ImageListUI(bpy.types.UIList):
 
 def guidialogmod(modifier, layout, context):
     layout.prop_menu_enum(modifier, "versions")
-    layout.separator()
-    
+
     split = layout.split()
     main_col = split.column()
-    
-    layout.label("GUI Objects:")
+
     main_col.label("Required:")
     col = main_col.column()
     col.prop(modifier, "gui_clickable", text="Clickable")

--- a/korman/ui/modifiers/gui.py
+++ b/korman/ui/modifiers/gui.py
@@ -27,6 +27,24 @@ class ImageListUI(bpy.types.UIList):
             layout.prop(item, "enabled", text="")
 
 
+def guidialogmod(modifier, layout, context):
+    layout.prop_menu_enum(modifier, "versions")
+    layout.separator()
+    
+    split = layout.split()
+    main_col = split.column()
+    
+    layout.label("GUI Objects:")
+    main_col.label("Required:")
+    col = main_col.column()
+    col.prop(modifier, "clickable", text="Clickable")
+    col.prop(modifier, "gui_object", text="GUI Object")
+    main_col.separator()
+    main_col.label("Optional:")
+    col = main_col.column(align=True)
+    col.prop(modifier, "region", text="Click Region")
+    col.prop(modifier, "button", text="GUI Button")
+
 def imagelibmod(modifier, layout, context):
     ui_list.draw_modifier_list(layout, "ImageListUI", modifier, "images", "active_image_index", rows=3, maxrows=6)
 


### PR DESCRIPTION
Adds the beginnings of the basic custom GUI dialog modifier.

The goal will be to eventually create a simple GUI Dialog mod for single images per #136 , along with the required Post Effects Mod plus (optional) GUI Button for clicking off.

Along with the basic components, there is a crude sanity check to make sure there's at least a clickable and the GUI object itself, plus a pre-export def to check for the version(s) for export.

The modifier itself indicates what is required and what is optional, but of course, the final layout is up for suggestions.

It still needs the actual export component and probably a few other things. Presumably, there's things that need to be done so we don't need to mirror the GUI object's texture backwards or rotate the camera (empty?) to face away after setup.

At the end, we need a GUI Dialog Mod, a Post Effects Mod, an (optional) GUI Button Mod, and a Python script reference for xDialogToggle.py, everything with all the trimmings.

I'm also not sure if we want this to be more broad and use the opportunity to also work on the aforementioned dialog nodes/PRPs detailed in the referenced issue.

Also, minor issue: The name/label is cut off as "Dialog" in the modifier drop-down menu.