### PR TITLE
Add Local Only to Sound Emitter Modifier

### DIFF
--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -804,6 +804,7 @@ class PlasmaSoundMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacksNo
 
     def _convert_random_sound_msg(self, exporter, so):
         # Yas, plAnimCmdMsg
+        soundemit = self.emitter_object.plasma_modifiers.soundemit
         msg = plAnimCmdMsg()
         msg.addReceiver(exporter.mgr.find_key(plRandomSoundMod, bl=self.emitter_object))
 
@@ -818,6 +819,10 @@ class PlasmaSoundMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacksNo
             # No, you are not imagining things...
             msg.setCmd(plAnimCmdMsg.kSetSpeed, True)
         msg.speed = self.volume_pct / 100.0 if self.volume == "CUSTOM" else 0.0
+        # Checking for local only
+        for snd in soundemit.sounds:
+            if snd.local_only:
+                msg.setCmd(plAnimCmdMsg.kIsLocalOnly, True)
 
         yield msg
 
@@ -858,6 +863,10 @@ class PlasmaSoundMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacksNo
                 msg.setCmd(getattr(plSoundMsg, self.looping))
             if self.action != "CURRENT":
                 msg.setCmd(getattr(plSoundMsg, self.action))
+            # Is the sound local? Let's check the modifier...
+            for snd in soundemit.sounds:
+                if snd.local_only:
+                    msg.setCmd(plSoundMsg.kIsLocalOnly)
 
             # Because we might be giving two messages here...
             yield msg

--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -804,7 +804,6 @@ class PlasmaSoundMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacksNo
 
     def _convert_random_sound_msg(self, exporter, so):
         # Yas, plAnimCmdMsg
-        soundemit = self.emitter_object.plasma_modifiers.soundemit
         msg = plAnimCmdMsg()
         msg.addReceiver(exporter.mgr.find_key(plRandomSoundMod, bl=self.emitter_object))
 
@@ -819,10 +818,6 @@ class PlasmaSoundMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacksNo
             # No, you are not imagining things...
             msg.setCmd(plAnimCmdMsg.kSetSpeed, True)
         msg.speed = self.volume_pct / 100.0 if self.volume == "CUSTOM" else 0.0
-        # Checking for local only
-        for snd in soundemit.sounds:
-            if snd.local_only:
-                msg.setCmd(plAnimCmdMsg.kIsLocalOnly, True)
 
         yield msg
 
@@ -863,10 +858,6 @@ class PlasmaSoundMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacksNo
                 msg.setCmd(getattr(plSoundMsg, self.looping))
             if self.action != "CURRENT":
                 msg.setCmd(getattr(plSoundMsg, self.action))
-            # Is the sound local? Let's check the modifier...
-            for snd in soundemit.sounds:
-                if snd.local_only:
-                    msg.setCmd(plSoundMsg.kIsLocalOnly)
 
             # Because we might be giving two messages here...
             yield msg

--- a/korman/properties/modifiers/sound.py
+++ b/korman/properties/modifiers/sound.py
@@ -373,7 +373,12 @@ class PlasmaSound(idprops.IDPropMixin, bpy.types.PropertyGroup):
         if self.incidental:
             sound.properties |= plSound.kPropIncidental
         if self.local_only:
-            sound.properties |= plSound.kPropLocalOnly
+            # Local only and random sounds hate each other, so we must check for both
+            for i in bpy.data.objects:
+                if i.plasma_modifiers.random_sound:
+                    raise ExportError("SoundEmitter '{}': cannot have local only sounds and a random sound mod.".format(self.id_data.name))
+                else:
+                    sound.properties |= plSound.kPropLocalOnly
         sound.dataBuffer = self._find_sound_buffer(exporter, so, wavHeader, dataSize, channel)
 
         # Cone effect

--- a/korman/properties/modifiers/sound.py
+++ b/korman/properties/modifiers/sound.py
@@ -243,6 +243,10 @@ class PlasmaSound(idprops.IDPropMixin, bpy.types.PropertyGroup):
                         description="Loop the sound",
                         default=False,
                         options=set())
+    local_only = BoolProperty(name"Local Only",
+                              description="Sounds only plays for local avatar",
+                              default=False,
+                              options=set())
 
     inner_cone = FloatProperty(name="Inner Angle",
                                description="Angle of the inner cone from the negative Z-axis",
@@ -368,6 +372,8 @@ class PlasmaSound(idprops.IDPropMixin, bpy.types.PropertyGroup):
             sound.properties |= plSound.kPropLooping
         if self.incidental:
             sound.properties |= plSound.kPropIncidental
+        if self.local_only:
+            sound.properties |= plSound.kPropIsLocalOnly
         sound.dataBuffer = self._find_sound_buffer(exporter, so, wavHeader, dataSize, channel)
 
         # Cone effect

--- a/korman/properties/modifiers/sound.py
+++ b/korman/properties/modifiers/sound.py
@@ -373,7 +373,7 @@ class PlasmaSound(idprops.IDPropMixin, bpy.types.PropertyGroup):
         if self.incidental:
             sound.properties |= plSound.kPropIncidental
         if self.local_only:
-            sound.properties |= plSound.kPropIsLocalOnly
+            sound.properties |= plSound.kPropLocalOnly
         sound.dataBuffer = self._find_sound_buffer(exporter, so, wavHeader, dataSize, channel)
 
         # Cone effect

--- a/korman/properties/modifiers/sound.py
+++ b/korman/properties/modifiers/sound.py
@@ -373,12 +373,7 @@ class PlasmaSound(idprops.IDPropMixin, bpy.types.PropertyGroup):
         if self.incidental:
             sound.properties |= plSound.kPropIncidental
         if self.local_only:
-            # Local only and random sounds hate each other, so we must check for both
-            for i in bpy.data.objects:
-                if i.plasma_modifiers.random_sound:
-                    raise ExportError("SoundEmitter '{}': cannot have local only sounds and a random sound mod.".format(self.id_data.name))
-                else:
-                    sound.properties |= plSound.kPropLocalOnly
+            sound.properties |= plSound.kPropLocalOnly
         sound.dataBuffer = self._find_sound_buffer(exporter, so, wavHeader, dataSize, channel)
 
         # Cone effect

--- a/korman/ui/modifiers/sound.py
+++ b/korman/ui/modifiers/sound.py
@@ -110,6 +110,7 @@ def soundemit(modifier, layout, context):
         col.prop(sound, "auto_start")
         col.prop(sound, "incidental")
         col.prop(sound, "loop")
+        col.prop(sound, "local_only")
 
         col.separator()
         _draw_fade_ui(sound.fade_in, col, "Fade In:")


### PR DESCRIPTION
Adds the "Local Only/kIsLocalOnly" property to sound emitter modifiers. Dependent on the kPropIsLocalOnly attribute, which still needs to be added to libHSPlasma (unless I'm using the wrong definition?).

This will allow better sound control per client/avatar, which Ages like Tiam and Descent will need.