### PR TITLE
Fix vertex duplication

### DIFF
--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -440,7 +440,7 @@ class MeshConverter(_MeshManager):
 
             # Convert to per-material indices
             for j, vertex in enumerate(tessface.vertices):
-                uvws = tuple([uvw[j] for uvw in tessface_uvws])
+                uvws = tuple([tuple(uvw[j]) for uvw in tessface_uvws])
 
                 # Calculate vertex colors.
                 if mat2span_LUT:


### PR DESCRIPTION
Fixes a small issue with Korman's vertex de-duplication code.

Korman compares vertex color/uvws in order to determine if a vertex has already been exported. However, uvws are stored in `bpy_prop_array`s, which are compared by reference and not by value.

This results in Korman exporting exactly 3 vertices per triangles, which also means lower vertex count limit, slightly worse ingame performances, etc.

Casting the `bpy_prop_array`s to tuples fixes that. The difference can be observed by reimporting Ages using ZLZ with the "Normals: None" option.