### PR TITLE
Fix vcol cleaning bug with polygons

### DIFF
--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -242,9 +242,15 @@ class LightBaker:
                                 # Now for the Fun Stuff(c)... First, actually get ahold of the other
                                 # face (the one we're connected to via this edge).
                                 other_face = next(f for f in edge.link_faces if f != face)
+                                if not other_face.calc_area():
+                                    # Zero area face, ignore it.
+                                    continue
                                 # Now get ahold of the loop sharing our vertex on the OTHER SIDE
                                 # of that damnable edge...
                                 other_loop = next(loop for loop in other_face.loops if loop.vert == vert)
+                                if not other_loop.is_convex:
+                                    # Happens with complex polygons after edge dissolving. Ignore it.
+                                    continue
                                 other_color = other_loop[light_vcol]
                                 # Phew ! Good, now just pick whichever color has the highest average value
                                 if sum(max_color) / 3 < sum(other_color) / 3:


### PR DESCRIPTION
Vertex color cleaning (#270) can fail on some polygons, which results in random vertices being fully white.

This is caused by a Blender bug, which prevent baking loops made of three aligned vertices when using polygons instead of regular tris/quads. This is rare but can happen with some workflows. (The bug itself is probably because of something like triangulation problems within Blender).

We detect such cases with `loop.is_convex`. Convex loops are those for which the angle between the two connected edges is superior or equal to 180°.
(Ideally we should check whether the angle is exactly 180°, but that can be a bit tricky due to floating point precision. `is_convex` still yields good enough results AFAICT, and takes care of the main issue.)

![vcol_polygon](https://user-images.githubusercontent.com/2261279/147882201-0eb0485b-9a19-4a39-9f9c-212cf092e82d.jpg)
