### PR TITLE
Dynamic envmap: let the engine use default fog settings.

### DIFF
--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -742,9 +742,8 @@ class MaterialConverter:
         pl_env.incCharacters = texture.plasma_layer.envmap_addavatar
 
         # Perhaps the DEM/DCM fog should be separately configurable at some point?
-        pl_fog = bpy.context.scene.world.plasma_fni
         pl_env.color = utils.color(texture.plasma_layer.envmap_color)
-        pl_env.fogStart = pl_fog.fog_start
+        pl_env.fogStart = -1.0
 
         # EffVisSets
         # Whoever wrote this PyHSPlasma binding didn't follow the convention. Sigh.


### PR DESCRIPTION
Dynamic envmaps have a "FogStart" attribute. By default it should be set to a negative number to let the engine use the current fog settings, [as seen here](https://github.com/H-uru/Plasma/blob/master/Sources/Plasma/FeatureLib/pfDXPipeline/plDXPipeline.cpp#L4082).
Setting it to zero or a positive number will fiddle with fog settings in a way we probably don't want. I don't know the specifics, but in my case this makes the fog disappear from reflective objects (such as large bodies of water).