### PR TITLE
Add kDynamicBlocker collider toggle.

### DIFF
--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -165,28 +165,27 @@ class PhysicsConverter:
                 physical.friction = mod.friction
                 physical.restitution = mod.restitution
 
-                if not mod.dynamic_blocker:
-                    if mod.dynamic:
-                        if ver <= pvPots:
-                            physical.collideGroup = (1 << plSimDefs.kGroupDynamic) | \
-                                                    (1 << plSimDefs.kGroupStatic)
-                        physical.memberGroup = plSimDefs.kGroupDynamic
-                        physical.mass = mod.mass
-                        _set_phys_prop(plSimulationInterface.kStartInactive, simIface, physical,
-                                       value=mod.start_asleep)
-                    elif not mod.avatar_blocker:
-                        physical.memberGroup = plSimDefs.kGroupLOSOnly
-                    else:
-                        physical.memberGroup = plSimDefs.kGroupStatic
-
-                    # Line of Sight DB
-                    if mod.camera_blocker:
-                        physical.LOSDBs |= plSimDefs.kLOSDBCameraBlockers
-                        _set_phys_prop(plSimulationInterface.kCameraAvoidObject, simIface, physical)
-                    if mod.terrain:
-                        physical.LOSDBs |= plSimDefs.kLOSDBAvatarWalkable
-                else:
+                if mod.dynamic:
+                    if ver <= pvPots:
+                        physical.collideGroup = (1 << plSimDefs.kGroupDynamic) | \
+                                                (1 << plSimDefs.kGroupStatic)
+                    physical.memberGroup = plSimDefs.kGroupDynamic
+                    physical.mass = mod.mass
+                    _set_phys_prop(plSimulationInterface.kStartInactive, simIface, physical,
+                                   value=mod.start_asleep)
+                elif mod.dynamic_blocker and not mod.avatar_blocker:
                     physical.memberGroup = plSimDefs.kDynamicBlocker
+                elif not mod.avatar_blocker and not mod.dynamic_blocker:
+                    physical.memberGroup = plSimDefs.kGroupLOSOnly
+                else:
+                    physical.memberGroup = plSimDefs.kGroupStatic
+
+                # Line of Sight DB
+                if mod.camera_blocker:
+                    physical.LOSDBs |= plSimDefs.kLOSDBCameraBlockers
+                    _set_phys_prop(plSimulationInterface.kCameraAvoidObject, simIface, physical)
+                if mod.terrain:
+                    physical.LOSDBs |= plSimDefs.kLOSDBAvatarWalkable
 
                     # Hacky? We'd like to share the simple surface descriptors(TM) as much as possible...
                     # This could result in a few orphaned PhysicalSndGroups, but I think that's preferable

--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -187,13 +187,13 @@ class PhysicsConverter:
                 if mod.terrain:
                     physical.LOSDBs |= plSimDefs.kLOSDBAvatarWalkable
 
-                    # Hacky? We'd like to share the simple surface descriptors(TM) as much as possible...
-                    # This could result in a few orphaned PhysicalSndGroups, but I think that's preferable
-                    # to having a bunch of empty objects...?
+                # Hacky? We'd like to share the simple surface descriptors(TM) as much as possible...
+                # This could result in a few orphaned PhysicalSndGroups, but I think that's preferable
+                # to having a bunch of empty objects...?
                 if mod.surface != "kNone":
-                        sndgroup = self._mgr.find_create_object(plPhysicalSndGroup, so=so, name="SURFACEGEN_{}".format(mod.surface))
-                        sndgroup.group = getattr(plPhysicalSndGroup, mod.surface)
-                        physical.soundGroup = sndgroup.key
+                    sndgroup = self._mgr.find_create_object(plPhysicalSndGroup, so=so, name="SURFACEGEN_{}".format(mod.surface))
+                    sndgroup.group = getattr(plPhysicalSndGroup, mod.surface)
+                    physical.soundGroup = sndgroup.key
             else:
                 group_name = kwargs.get("member_group")
                 if group_name:

--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -174,7 +174,8 @@ class PhysicsConverter:
                     _set_phys_prop(plSimulationInterface.kStartInactive, simIface, physical,
                                    value=mod.start_asleep)
                 elif mod.dynamic_blocker and not mod.avatar_blocker:
-                    physical.memberGroup = plSimDefs.kGroupDynamicBlocker
+                    physical.collideGroup = (1 << plSimDefs.kGroupDynamic)
+                    physical.memberGroup = plSimDefs.kGroupDynamic
                 elif not mod.avatar_blocker and not mod.dynamic_blocker:
                     physical.memberGroup = plSimDefs.kGroupLOSOnly
                 else:

--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -165,33 +165,36 @@ class PhysicsConverter:
                 physical.friction = mod.friction
                 physical.restitution = mod.restitution
 
-                if mod.dynamic:
-                    if ver <= pvPots:
-                        physical.collideGroup = (1 << plSimDefs.kGroupDynamic) | \
-                                                (1 << plSimDefs.kGroupStatic)
-                    physical.memberGroup = plSimDefs.kGroupDynamic
-                    physical.mass = mod.mass
-                    _set_phys_prop(plSimulationInterface.kStartInactive, simIface, physical,
-                                   value=mod.start_asleep)
-                elif not mod.avatar_blocker:
-                    physical.memberGroup = plSimDefs.kGroupLOSOnly
+                if not mod.dynamic_blocker:
+                    if mod.dynamic:
+                        if ver <= pvPots:
+                            physical.collideGroup = (1 << plSimDefs.kGroupDynamic) | \
+                                                    (1 << plSimDefs.kGroupStatic)
+                        physical.memberGroup = plSimDefs.kGroupDynamic
+                        physical.mass = mod.mass
+                        _set_phys_prop(plSimulationInterface.kStartInactive, simIface, physical,
+                                       value=mod.start_asleep)
+                    elif not mod.avatar_blocker:
+                        physical.memberGroup = plSimDefs.kGroupLOSOnly
+                    else:
+                        physical.memberGroup = plSimDefs.kGroupStatic
+
+                    # Line of Sight DB
+                    if mod.camera_blocker:
+                        physical.LOSDBs |= plSimDefs.kLOSDBCameraBlockers
+                        _set_phys_prop(plSimulationInterface.kCameraAvoidObject, simIface, physical)
+                    if mod.terrain:
+                        physical.LOSDBs |= plSimDefs.kLOSDBAvatarWalkable
                 else:
-                    physical.memberGroup = plSimDefs.kGroupStatic
+                    physical.memberGroup = plSimDefs.kDynamicBlocker
 
-                # Line of Sight DB
-                if mod.camera_blocker:
-                    physical.LOSDBs |= plSimDefs.kLOSDBCameraBlockers
-                    _set_phys_prop(plSimulationInterface.kCameraAvoidObject, simIface, physical)
-                if mod.terrain:
-                    physical.LOSDBs |= plSimDefs.kLOSDBAvatarWalkable
-
-                # Hacky? We'd like to share the simple surface descriptors(TM) as much as possible...
-                # This could result in a few orphaned PhysicalSndGroups, but I think that's preferable
-                # to having a bunch of empty objects...?
+                    # Hacky? We'd like to share the simple surface descriptors(TM) as much as possible...
+                    # This could result in a few orphaned PhysicalSndGroups, but I think that's preferable
+                    # to having a bunch of empty objects...?
                 if mod.surface != "kNone":
-                    sndgroup = self._mgr.find_create_object(plPhysicalSndGroup, so=so, name="SURFACEGEN_{}".format(mod.surface))
-                    sndgroup.group = getattr(plPhysicalSndGroup, mod.surface)
-                    physical.soundGroup = sndgroup.key
+                        sndgroup = self._mgr.find_create_object(plPhysicalSndGroup, so=so, name="SURFACEGEN_{}".format(mod.surface))
+                        sndgroup.group = getattr(plPhysicalSndGroup, mod.surface)
+                        physical.soundGroup = sndgroup.key
             else:
                 group_name = kwargs.get("member_group")
                 if group_name:

--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -175,7 +175,7 @@ class PhysicsConverter:
                                    value=mod.start_asleep)
                 elif mod.dynamic_blocker and not mod.avatar_blocker:
                     physical.collideGroup = (1 << plSimDefs.kGroupDynamic)
-                    physical.memberGroup = plSimDefs.kGroupDynamic
+                    physical.memberGroup = plSimDefs.kGroupLOSOnly
                 elif not mod.avatar_blocker and not mod.dynamic_blocker:
                     physical.memberGroup = plSimDefs.kGroupLOSOnly
                 else:

--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -174,7 +174,7 @@ class PhysicsConverter:
                     _set_phys_prop(plSimulationInterface.kStartInactive, simIface, physical,
                                    value=mod.start_asleep)
                 elif mod.dynamic_blocker and not mod.avatar_blocker:
-                    physical.memberGroup = plSimDefs.kDynamicBlocker
+                    physical.memberGroup = plSimDefs.kGroupDynamicBlocker
                 elif not mod.avatar_blocker and not mod.dynamic_blocker:
                     physical.memberGroup = plSimDefs.kGroupLOSOnly
                 else:

--- a/korman/properties/modifiers/physics.py
+++ b/korman/properties/modifiers/physics.py
@@ -82,7 +82,7 @@ class PlasmaCollider(PlasmaModifierProperties):
                                   default=True)
     dynamic_blocker = BoolProperty(name="Blocks Dynamics",
                                    description="Object blocks dynamic objects (kickables)",
-                                   default=False)
+                                   default=True)
 
     friction = FloatProperty(name="Friction",
                              min=0.0,

--- a/korman/properties/modifiers/physics.py
+++ b/korman/properties/modifiers/physics.py
@@ -69,18 +69,42 @@ class PlasmaCollider(PlasmaModifierProperties):
     bl_icon = "MOD_PHYSICS"
     bl_description = "Simple physical collider"
 
-    bounds = EnumProperty(name="Bounds Type", description="", items=bounds_types, default="hull")
+    bounds = EnumProperty(name="Bounds Type",
+                          description="",
+                          items=bounds_types,
+                          default="hull")
 
-    avatar_blocker = BoolProperty(name="Blocks Avatars", description="Object blocks avatars", default=True)
-    camera_blocker = BoolProperty(name="Blocks Camera LOS", description="Object blocks camera line-of-sight", default=True)
+    avatar_blocker = BoolProperty(name="Blocks Avatars",
+                                  description="Object blocks avatars",
+                                  default=True)
+    camera_blocker = BoolProperty(name="Blocks Camera LOS",
+                                  description="Object blocks camera line-of-sight",
+                                  default=True)
+    dynamic_blocker = BoolProperty(name="Blocks Dynamics",
+                                   description="Object blocks dynamic objects (kickables)",
+                                   default=False)
 
-    friction = FloatProperty(name="Friction", min=0.0, default=0.5)
-    restitution = FloatProperty(name="Restitution", description="Coefficient of collision elasticity", min=0.0, max=1.0)
-    terrain = BoolProperty(name="Terrain", description="Object represents the ground", default=False)
+    friction = FloatProperty(name="Friction",
+                             min=0.0,
+                             default=0.5)
+    restitution = FloatProperty(name="Restitution",
+                                description="Coefficient of collision elasticity",
+                                min=0.0,
+                                max=1.0)
+    terrain = BoolProperty(name="Terrain",
+                           description="Object represents the ground",
+                           default=False)
 
-    dynamic = BoolProperty(name="Dynamic", description="Object can be influenced by other objects (ie is kickable)", default=False)
-    mass = FloatProperty(name="Mass", description="Mass of object in pounds", min=0.0, default=1.0)
-    start_asleep = BoolProperty(name="Start Asleep", description="Object is not active until influenced by another object", default=False)
+    dynamic = BoolProperty(name="Dynamic",
+                           description="Object can be influenced by other objects (ie is kickable)",
+                           default=False)
+    mass = FloatProperty(name="Mass",
+                         description="Mass of object in pounds",
+                         min=0.0,
+                         default=1.0)
+    start_asleep = BoolProperty(name="Start Asleep",
+                                description="Object is not active until influenced by another object",
+                                default=False)
 
     proxy_object = PointerProperty(name="Proxy",
                                    description="Object used as the collision geometry",
@@ -118,9 +142,12 @@ class PlasmaSubworld(PlasmaModifierProperties):
                             default="auto",
                             options=set())
     gravity = FloatVectorProperty(name="Gravity",
-        description="Subworld's gravity defined in feet per second squared",
-        size=3, default=(0.0, 0.0, -32.174), precision=3,
-        subtype="ACCELERATION", unit="ACCELERATION")
+                                  description="Subworld's gravity defined in feet per second squared",
+                                  size=3,
+                                  default=(0.0, 0.0, -32.174),
+                                  precision=3,
+                                  subtype="ACCELERATION",
+                                  unit="ACCELERATION")
 
     def export(self, exporter, bo, so):
         if self.is_dedicated_subworld(exporter):

--- a/korman/ui/modifiers/physics.py
+++ b/korman/ui/modifiers/physics.py
@@ -21,7 +21,6 @@ def collision(modifier, layout, context):
     split = layout.split()
     col = split.column()
     col.prop(modifier, "dynamic_blocker")
-    col.active != modifier.dynamic_blocker)
     col.prop(modifier, "avatar_blocker")
     col.prop(modifier, "camera_blocker")
     col.prop(modifier, "terrain")

--- a/korman/ui/modifiers/physics.py
+++ b/korman/ui/modifiers/physics.py
@@ -20,9 +20,9 @@ def collision(modifier, layout, context):
 
     split = layout.split()
     col = split.column()
-    col.prop(modifier, "dynamic_blocker")
     col.prop(modifier, "avatar_blocker")
     col.prop(modifier, "camera_blocker")
+    col.prop(modifier, "dynamic_blocker")
     col.prop(modifier, "terrain")
 
     col = split.column()

--- a/korman/ui/modifiers/physics.py
+++ b/korman/ui/modifiers/physics.py
@@ -20,6 +20,8 @@ def collision(modifier, layout, context):
 
     split = layout.split()
     col = split.column()
+    col.prop(modifier, "dynamic_blocker")
+    col.active != modifier.dynamic_blocker)
     col.prop(modifier, "avatar_blocker")
     col.prop(modifier, "camera_blocker")
     col.prop(modifier, "terrain")


### PR DESCRIPTION
Exports a collider that should hopefully block only dynamic objects (kickables). Also, some formatting adjustments to the properties script to match others (this can be undone if wanted)