### PR TITLE
Change Plasma Object default

### DIFF
--- a/korman/properties/prop_object.py
+++ b/korman/properties/prop_object.py
@@ -40,7 +40,7 @@ class PlasmaObject(bpy.types.PropertyGroup):
 
     enabled = BoolProperty(name="Export",
                            description="Export this as a discrete object",
-                           default=False,
+                           default=True,
                            update=_enabled)
     page = StringProperty(name="Page",
                           description="Page this object will be exported to")


### PR DESCRIPTION
Changes the default for the Plasma Object setting to True so that it's on by default when _adding_ an object. A QoL/convenience change for Age builders.

The change is only applied to _new_ objects and not existing (I've checked this), so it won't affect any existing work. It's something that's tripped up a few builders at various times (including me!).