### PR TITLE
A batch of collider usability improvements.

### DIFF
--- a/korman/exporter/physics.py
+++ b/korman/exporter/physics.py
@@ -281,6 +281,15 @@ class PhysicsConverter:
         # bake them to convex hulls. Specifically, Windows 32-bit w/PhysX 2.6. Everything else just
         # needs to have us provide some friendlier data...
         with bmesh_from_object(bo) as mesh:
+            # Don't export flat planes as convex hulls - force them to triangle meshes.
+            volume = mesh.calc_volume()
+            if volume < 0.001:
+                self._report.warn(
+                    "{}: Physical wants to be a convex hull but appears to be flat (volume={}), forcing to triangle mesh...",
+                    bo.name, volume, indent=2
+                )
+                self._export_trimesh(bo, physical, local_space, mat)
+
             if local_space:
                 physical.pos = hsVector3(*mat.to_translation())
                 physical.rot = utils.quaternion(mat.to_quaternion())

--- a/korman/nodes/node_conditions.py
+++ b/korman/nodes/node_conditions.py
@@ -174,7 +174,9 @@ class PlasmaClickableRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.t
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "region_object", icon="MESH_DATA")
+        layout.alert = self.bounds == "trimesh"
         layout.prop(self, "bounds")
+        layout.alert = False
 
     def convert_subcondition(self, exporter, parent_bo, parent_so, logicmod):
         # REMEMBER: parent_so doesn't have to be the actual region scene object...
@@ -379,7 +381,9 @@ class PlasmaVolumeSensorNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.type
 
         # Okay, if they changed the name of the ObData, that's THEIR problem...
         layout.prop(self, "region_object", icon="MESH_DATA")
+        layout.alert = self.bounds == "trimesh"
         layout.prop(self, "bounds")
+        layout.alert = False
 
     def get_key(self, exporter, parent_so):
         bo = self.region_object

--- a/korman/ui/modifiers/region.py
+++ b/korman/ui/modifiers/region.py
@@ -16,6 +16,12 @@
 import bpy
 from .. import ui_camera
 
+def _draw_bounds_prop(modifier, layout, context, *, local_prop: bool = False):
+    prop_source = modifier if local_prop else modifier.id_data.plasma_modifiers.collision
+    layout.alert = prop_source.bounds == "trimesh"
+    layout.prop(prop_source, "bounds")
+    layout.alert = False
+
 def camera_rgn(modifier, layout, context):
     layout.prop(modifier, "camera_type")
     if modifier.camera_type == "manual":
@@ -35,12 +41,11 @@ def camera_rgn(modifier, layout, context):
                              ui_camera.draw_camera_manipulation_props))
 
 def footstep(modifier, layout, context):
-    layout.prop(modifier, "bounds")
+    _draw_bounds_prop(modifier, layout, context, local_prop=True)
     layout.prop(modifier, "surface")
 
 def paniclink(modifier, layout, context):
-    phys_mod = context.object.plasma_modifiers.collision
-    layout.prop(phys_mod, "bounds")
+    _draw_bounds_prop(modifier, layout, context)
     layout.prop(modifier, "play_anim")
 
 def softvolume(modifier, layout, context):
@@ -61,6 +66,5 @@ def softvolume(modifier, layout, context):
 
 def subworld_rgn(modifier, layout, context):
     layout.prop(modifier, "subworld")
-    collision_mod = modifier.id_data.plasma_modifiers.collision
-    layout.prop(collision_mod, "bounds")
+    _draw_bounds_prop(modifier, layout, context)
     layout.prop(modifier, "transition")


### PR DESCRIPTION
This addresses some common gotchas with exported colliders:
- Flat convex hulls (planes) are now forced to triangle meshes.
- Triangle mesh regions will cause the export to error on MOUL and Myst V mode because the physics engines in those games either do not support this combination or only partially support it.
- Triangle mesh regions now alert in the UI, where appropriate.