### PR TITLE
Fix potential wind object gotcha.

### DIFF
--- a/korman/properties/modifiers/water.py
+++ b/korman/properties/modifiers/water.py
@@ -243,7 +243,7 @@ class PlasmaWaterModifier(idprops.IDPropMixin, PlasmaModifierProperties, bpy.typ
     def export(self, exporter, bo, so):
         waveset = exporter.mgr.find_create_object(plWaveSet7, name=bo.name, so=so)
         if self.wind_object:
-            if self.wind_object.plasma_object.enabled and self.wind_object.plasma_modifiers.animation.enabled:
+            if exporter.has_coordiface(self.wind_object):
                 waveset.refObj = exporter.mgr.find_create_key(plSceneObject, bl=self.wind_object)
                 waveset.setFlag(plWaveSet7.kHasRefObject, True)
 


### PR DESCRIPTION
If a wind object is *not* animated but rather moved via logic nodes (eg a Python script), then the previous logic wouldn't allow for the in-game wind direction to change. It's important to check if the wind object has a coordinate interface (can it move?) instead of if it's animated (did the artist move it?).