### PR TITLE
Add xSitCam.py functionality to Sitting Modifier

### DIFF
--- a/korman/properties/modifiers/avatar.py
+++ b/korman/properties/modifiers/avatar.py
@@ -122,10 +122,10 @@ class PlasmaSittingBehavior(idprops.IDPropObjectMixin, PlasmaModifierProperties,
                                  description="How far away we will tolerate the avatar facing the clickable",
                                  min=-180, max=180, default=45)
     sitting_camera = PointerProperty(name="Camera (optional)",
-                                  description="Activate a specific camera when sitting down",
-                                  type=bpy.types.Object,
-                                  poll=idprops.poll_camera_objects,
-                                  options=set())
+                                     description="Activate a specific camera when sitting down",
+                                     type=bpy.types.Object,
+                                     poll=idprops.poll_camera_objects,
+                                     options=set())
 
     def harvest_actors(self):
         if self.facing_enabled:
@@ -142,10 +142,12 @@ class PlasmaSittingBehavior(idprops.IDPropObjectMixin, PlasmaModifierProperties,
         if self.sitting_camera is not None:
             sittingpynode = self._create_python_file_node(tree, sitting_pfm["filename"], sitting_pfm["attribs"])
             sittingmod.link_output(sittingpynode, "satisfies", "sitAct")
+
             # Camera Object
             cameraobj = nodes.new("PlasmaAttribObjectNode")
             cameraobj.link_output(sittingnode, "pfm", "sitCam")
             cameraobj.target_object = self.sitting_camera
+
         # Clickable
         clickable = nodes.new("PlasmaClickableNode")
         clickable.link_output(sittingmod, "satisfies", "condition")

--- a/korman/properties/modifiers/avatar.py
+++ b/korman/properties/modifiers/avatar.py
@@ -83,7 +83,7 @@ sitting_pfms = {
     "filename": "xSitCam.py",
     "attribs": (
         { 'id':  1, 'type': "ptAttribActivator", 'name': "sitAct" },
-        { 'id':  2, 'type': "ptAttribSceneObject", 'name': "sitCam" },
+        { 'id':  2, 'type': "ptAttribSceneobject", 'name': "sitCam" },
     )
 }
 

--- a/korman/properties/modifiers/avatar.py
+++ b/korman/properties/modifiers/avatar.py
@@ -78,6 +78,16 @@ class PlasmaLadderModifier(PlasmaModifierProperties):
         return True
 
 
+# Use xSitCam.py for when we want a camera to pop up
+sitting_pfms = {
+    "filename": "xSitCam.py",
+    "attribs": (
+        { 'id':  1, 'type': "ptAttribActivator", 'name': "sitAct" },
+        { 'id':  2, 'type': "ptAttribSceneObject", 'name': "sitCam" },
+    )
+}
+
+
 sitting_approach_flags = [("kApproachFront", "Front", "Approach from the font"),
                           ("kApproachLeft", "Left", "Approach from the left"),
                           ("kApproachRight", "Right", "Approach from the right"),
@@ -111,6 +121,11 @@ class PlasmaSittingBehavior(idprops.IDPropObjectMixin, PlasmaModifierProperties,
     facing_degrees = IntProperty(name="Tolerance",
                                  description="How far away we will tolerate the avatar facing the clickable",
                                  min=-180, max=180, default=45)
+    sitting_cam = PointerProperty(name="Camera (optional)",
+                                  description="Activate a specific camera when sitting down",
+                                  type=bpy.types.Object,
+                                  poll=idprops.poll_camera_objects,
+                                  options=set())
 
     def harvest_actors(self):
         if self.facing_enabled:
@@ -119,16 +134,61 @@ class PlasmaSittingBehavior(idprops.IDPropObjectMixin, PlasmaModifierProperties,
     def logicwiz(self, bo, tree):
         nodes = tree.nodes
 
+        if not self.sitting_cam:
+            # Sitting Modifier
+            sittingmod = nodes.new("PlasmaSittingBehaviorNode")
+            sittingmod.approach = self.approach
+            sittingmod.name = "SittingBeh"
+
+            # Clickable
+            clickable = nodes.new("PlasmaClickableNode")
+            clickable.link_output(sittingmod, "satisfies", "condition")
+            clickable.clickable_object = self.clickable_object
+            clickable.bounds = find_modifier(self.clickable_object, "collision").bounds
+
+            # Avatar Region (optional)
+            region_phys = find_modifier(self.region_object, "collision")
+            if region_phys is not None:
+                region = nodes.new("PlasmaClickableRegionNode")
+                region.link_output(clickable, "satisfies", "region")
+                region.name = "ClickableAvRegion"
+                region.region_object = self.region_object
+                region.bounds = region_phys.bounds
+
+            # Facing Target (optional)
+            if self.facing_enabled:
+                facing = nodes.new("PlasmaFacingTargetNode")
+                facing.link_output(clickable, "satisfies", "facing")
+                facing.name = "FacingClickable"
+                facing.directional = True
+                facing.tolerance = self.facing_degrees
+            else:
+                # this socket must be explicitly disabled, otherwise it automatically generates a default
+                # facing target conditional for us. isn't that nice?
+                clickable.find_input_socket("facing").allow_simple = False
+        else:
+            sitting_pfm = sitting_pfms
+            sittingnode = self._create_python_file_node(tree, sitting_pfm["filename"], sitting_pfm["attribs"])
+            self._create_sitting_nodes(bo, tree.nodes, sittingnode)
+
+
+    def _create_sitting_nodes(self, clickable_object, nodes, sittingnode):
         # Sitting Modifier
         sittingmod = nodes.new("PlasmaSittingBehaviorNode")
         sittingmod.approach = self.approach
         sittingmod.name = "SittingBeh"
+        sittingmod.link_output(sittingnode, "satisfies", "sitAct")
 
         # Clickable
         clickable = nodes.new("PlasmaClickableNode")
         clickable.link_output(sittingmod, "satisfies", "condition")
         clickable.clickable_object = self.clickable_object
         clickable.bounds = find_modifier(self.clickable_object, "collision").bounds
+
+        # Camera Object
+        cameraobj = nodes.new("PlasmaAttribObjectNode")
+        cameraobj.link_output(sittingnode, "pfm", "sitCam")
+        cameraobj.target_object = self.sitting_cam
 
         # Avatar Region (optional)
         region_phys = find_modifier(self.region_object, "collision")

--- a/korman/properties/modifiers/avatar.py
+++ b/korman/properties/modifiers/avatar.py
@@ -121,7 +121,7 @@ class PlasmaSittingBehavior(idprops.IDPropObjectMixin, PlasmaModifierProperties,
     facing_degrees = IntProperty(name="Tolerance",
                                  description="How far away we will tolerate the avatar facing the clickable",
                                  min=-180, max=180, default=45)
-    sitting_camera = PointerProperty(name="Camera (optional)",
+    sitting_camera = PointerProperty(name="Camera",
                                      description="Activate a specific camera when sitting down",
                                      type=bpy.types.Object,
                                      poll=idprops.poll_camera_objects,

--- a/korman/ui/modifiers/avatar.py
+++ b/korman/ui/modifiers/avatar.py
@@ -41,6 +41,9 @@ def sittingmod(modifier, layout, context):
     if region is not None:
         col.prop(region, "bounds")
 
+    col = layout.column()
+    col.prop(modifier, "sitting_cam", icon="CAMERA_DATA")
+
     split = layout.split()
     split.column().prop(modifier, "facing_enabled")
     col = split.column()

--- a/korman/ui/modifiers/avatar.py
+++ b/korman/ui/modifiers/avatar.py
@@ -42,7 +42,7 @@ def sittingmod(modifier, layout, context):
         col.prop(region, "bounds")
 
     col = layout.column()
-    col.prop(modifier, "sitting_cam", icon="CAMERA_DATA")
+    col.prop(modifier, "sitting_camera", icon="CAMERA_DATA")
 
     split = layout.split()
     split.column().prop(modifier, "facing_enabled")


### PR DESCRIPTION
Adds new scripting to Sitting Modifier to use xSitCam.py if a camera is selected.

Note that, as of the first commit, the camera object does not attach to the proper node in the Python file script node and I'm not entirely sure why. **EDIT: This has since been fixed (see comment below).**