### PR TITLE
Add Takable Clothing Clickable Mod

### DIFF
--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -117,3 +117,163 @@ class PlasmaMaintainersMarker(PlasmaModifierProperties):
     @property
     def requires_actor(self):
         return True
+
+
+clothing_pfms = {
+    "filename": "xTakableClothing.py",
+    "attribs": (
+        { 'id':  1, 'type': "ptAttribString", 'name': "stringVarName" },
+        { 'id':  2, 'type': "ptAttribBoolean", 'name': "boolShowOnTrue" },
+        { 'id':  3, 'type': "ptAttribActivator", 'name': "actClickable" },
+        { 'id':  4, 'type': "ptAttribString", 'name': "stringFClothingName" },
+        { 'id':  5, 'type': "ptAttribString", 'name': "stringMClothingName" },
+        { 'id':  6, 'type': "ptAttribBoolean", 'name': "boolHasHairColor" },
+        { 'id':  7, 'type': "ptAttribString", 'name': "stringChanceSDLName" },
+        { 'id':  8, 'type': "ptAttribInt", 'name': "intTint1Red" },
+        { 'id':  9, 'type': "ptAttribInt", 'name': "intTint1Green" },
+        { 'id': 10, 'type': "ptAttribInt", 'name': "intTint1Blue" },
+        { 'id': 11, 'type': "ptAttribInt", 'name': "intTint2Red" },
+        { 'id': 12, 'type': "ptAttribInt", 'name': "intTint2Green" },
+        { 'id': 13, 'type': "ptAttribInt", 'name': "intTint2Blue" },
+        { 'id': 14, 'type': "ptAttribBoolean", 'name': "boolStayVisible" },
+        { 'id': 15, 'type': "ptAttribBoolean", 'name': "boolFirstUpdate" },
+    )
+}
+
+
+class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
+    pl_id = "clothing"
+
+    bl_category = "Logic"
+    bl_label = "Takable Clothing"
+    bl_description = "Set up clickable mesh for a collectable clothing item."
+    bl_icon = "POSE_HLT"
+
+    clickable_object = PointerProperty(name="Clickable",
+                                       description="Clickable mesh object for clothing item.",
+                                       options=set(),
+                                       type=bpy.types.Object,
+                                       poll=idprops.poll_mesh_objects)
+    clickable_region = PointerProperty(name="Region",
+                                       description="Region to activate clickable.",
+                                       options=set(),
+                                       type=bpy.types.Object,
+                                       poll=idprops.poll_mesh_objects)
+    clothing_sdl = StringProperty(name="SDL Variable",
+                                  description="SDL variable associated with the clothing item.",
+                                  options=set())
+    clothing_show = BoolProperty(name="Show on true?",
+                                 description="Have the clothing only appear when the SDL variable is true.",
+                                 default=False,
+                                 options=set())
+    clothing_male = StringProperty(name="Male ID",
+                                   description="ID name for male version of clothing.",
+                                   options=set())
+    clothing_female = StringProperty(name="Female ID",
+                                     description="ID name for female version of clothing.",
+                                     options=set())
+    clothing_chance = StringProperty(name="Chance SDL (optional)",
+                                     description="SDL variable for chance appearance of clothing.",
+                                     options=set())
+    clothing_tint1red = IntProperty(name="Tint 1 Red",
+                                    description="Red setting for first tint.",
+                                    min=0, max=255, default=255,
+                                    options=set())
+    clothing_tint1green = IntProperty(name="Tint 1 Green",
+                                    description="Green setting for first tint.",
+                                    min=0, max=255, default=255,
+                                    options=set())
+    clothing_tint1blue = IntProperty(name="Tint 1 Blue",
+                                    description="Blue setting for first tint.",
+                                    min=0, max=255, default=255,
+                                    options=set())
+    clothing_tint2on = BoolProperty(name="Second Tint?",
+                                    description="Does the clothing item have a second tint color?",
+                                    default=False,
+                                    options=set())
+    clothing_tint2red = IntProperty(name="Tint 2 Red",
+                                    description="Red setting for second tint.",
+                                    min=0, max=255, default=255,
+                                    options=set())
+    clothing_tint2green = IntProperty(name="Tint 2 Green",
+                                    description="Green setting for second tint.",
+                                    min=0, max=255, default=255,
+                                    options=set())
+    clothing_tint2blue = IntProperty(name="Tint 2 Blue",
+                                    description="Blue setting for second tint.",
+                                    min=0, max=255, default=255,
+                                    options=set())
+    clothing_stayvis = BoolProperty(name="Stay Visible After Click?",
+                                    description="Should the clothing stay visible after first clicking?",
+                                    default=False,
+                                    options=set())
+
+    def logicwiz(self, bo, tree):
+        nodes = tree.nodes
+
+        clothing_pfm = clothing_pfms
+        clothingnode = self._create_python_file_node(tree, clothing_pfm["filename"], clothing_pfm["attribs"])
+        self._create_clothing_nodes(bo, tree.nodes, imagernode)
+
+    def _create_clothing_node(self, clickable_object, nodes, clothingnode):
+        # Clickable
+        clickable = nodes.new("PlasmaClickableNode")
+        clickable.clickable_object = self.clickable_object
+        clickable.allow_simple = False
+        clickable.link_output(clothingnode, "satisfies", "actClickable")
+
+        # Region
+        clothingrgn = nodes.new("PlasmaClickableRegionNode")
+        clothingrgn.region_object = self.clickable_region
+        clothingrgn.link_output(clickable, "satisfies", "region")
+
+        # SDL Variable
+        clothingsdlvar = nodes.new("PlasmaAttribStringNode")
+        clothingsdlvar.value = self.clothing_sdl
+        clothingsdlvar.link_output(clothingnode, "pfm", "stringVarName")
+
+        # Show On True?
+        clothingshow = nodes.new("PlasmaAttribBoolNode")
+        clothingshow.value = self.clothing_show
+        clothingshow.link_output(clothingnode, "pfm", "boolShowOnTrue")
+
+        clothingfemale = nodes.new("PlasmaAttribStringNode")
+        clothingfemale.value = self.clothing_female
+        clothingfemale.link_output(clothingnode, "pfm", "stringFClothingName")
+
+        clothingmale = nodes.new("PlasmaAttribStringNode")
+        clothingmale.value = self.clothing_male
+        clothingmale.link_output(clothingnode, "pfm", "stringMClothingName")
+
+        clothingred1 = nodes.new("PlasmaAttribIntNode")
+        clothingred1.value_int = clothing_tint1red
+        clothingred1.link_output(clothingnode, "pfm", "intTint1Red")
+
+        clothinggreen1 = nodes.new("PlasmaAttribIntNode")
+        clothinggreen1.value_int = clothing_tint1green
+        clothinggreen1.link_output(clothingnode, "pfm", "intTint1Green")
+
+        clothingblue1 = nodes.new("PlasmaAttribIntNode")
+        clothingblue1.value_int = clothing_tint1blue
+        clothingblue1.link_output(clothingnode, "pfm", "intTint1Blue")
+
+        clothingred2 = nodes.new("PlasmaAttribIntNode")
+        clothingred2.value_int = clothing_tint2red
+        clothingred2.link_output(clothingnode, "pfm", "intTint2Red")
+
+        clothinggreen2 = nodes.new("PlasmaAttribIntNode")
+        clothinggreen2.value_int = clothing_tint2green
+        clothinggreen2.link_output(clothingnode, "pfm", "intTint2Green")
+
+        clothingblue2 = nodes.new("PlasmaAttribIntNode")
+        clothingblue2.value_int = clothing_tint2blue
+        clothingblue2.link_output(clothingnode, "pfm", "intTint2Blue")
+
+        clothingvis = nodes.new("PlasmaAttribBoolNode")
+        clothingvis.value = self.clothing_stayvis
+        clothingvis.link_output(clothingnode, "pfm", "boolStayVisible")
+
+        clothingeval = nodes.new("PlasmaAttribBoolNode")
+        clothingeval.value = False
+        clothingeval.link_output(clothingnode, "pfm", "boolFirstUpdate")
+

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -187,11 +187,6 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
                                          subtype="COLOR",
                                          min=0.0, max=1.0,
                                          default=(1.0, 1.0, 1.0))
-    clothing_tint2on = BoolProperty(name="Second Tint?",
-                                    description="Does the clothing item have a second tint color?",
-                                    default=False,
-                                    options=set())
-                                    options=set())
     clothing_stayvis = BoolProperty(name="Stay Visible After Click?",
                                     description="Should the clothing stay visible after first clicking?",
                                     default=False,

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -151,12 +151,10 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
 
     clickable_object = PointerProperty(name="Clickable",
                                        description="Clickable mesh object for clothing item.",
-                                       options=set(),
                                        type=bpy.types.Object,
                                        poll=idprops.poll_mesh_objects)
     clickable_region = PointerProperty(name="Region",
                                        description="Region to activate clickable.",
-                                       options=set(),
                                        type=bpy.types.Object,
                                        poll=idprops.poll_mesh_objects)
     clothing_sdl = StringProperty(name="SDL Variable",
@@ -164,6 +162,10 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
                                   options=set())
     clothing_show = BoolProperty(name="Show on true?",
                                  description="Have the clothing only appear when the SDL variable is true.",
+                                 default=False,
+                                 options=set())
+    clothing_hair = BoolProperty(name="Changes hair color?",
+                                 description="Should the hair change too?",
                                  default=False,
                                  options=set())
     clothing_male = StringProperty(name="Male ID",
@@ -237,6 +239,17 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         clothingshow.value = self.clothing_show
         clothingshow.link_output(clothingnode, "pfm", "boolShowOnTrue")
 
+        # Hair color?
+        clothinghair = nodes.new("PlasmaAttribBoolNode")
+        clothinghair.value = self.clothing_hair
+        clothinghair.link_output(clothingnode, "pfm", "boolHasHairColor")
+
+        # Chance SDL
+        clothingchance = nodes.new("PlasmaAttribStringNode")
+        clothingchance.value = self.clothing_chance
+        clothingchance.link_output(clothingnode, "pfm", "stringChanceSDLName")
+
+        # Colors, man!
         clothingfemale = nodes.new("PlasmaAttribStringNode")
         clothingfemale.value = self.clothing_female
         clothingfemale.link_output(clothingnode, "pfm", "stringFClothingName")
@@ -246,29 +259,30 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         clothingmale.link_output(clothingnode, "pfm", "stringMClothingName")
 
         clothingred1 = nodes.new("PlasmaAttribIntNode")
-        clothingred1.value_int = clothing_tint1red
+        clothingred1.value_int = self.clothing_tint1red
         clothingred1.link_output(clothingnode, "pfm", "intTint1Red")
 
         clothinggreen1 = nodes.new("PlasmaAttribIntNode")
-        clothinggreen1.value_int = clothing_tint1green
+        clothinggreen1.value_int = self.clothing_tint1green
         clothinggreen1.link_output(clothingnode, "pfm", "intTint1Green")
 
         clothingblue1 = nodes.new("PlasmaAttribIntNode")
-        clothingblue1.value_int = clothing_tint1blue
+        clothingblue1.value_int = self.clothing_tint1blue
         clothingblue1.link_output(clothingnode, "pfm", "intTint1Blue")
 
         clothingred2 = nodes.new("PlasmaAttribIntNode")
-        clothingred2.value_int = clothing_tint2red
+        clothingred2.value_int = self.clothing_tint2red
         clothingred2.link_output(clothingnode, "pfm", "intTint2Red")
 
         clothinggreen2 = nodes.new("PlasmaAttribIntNode")
-        clothinggreen2.value_int = clothing_tint2green
+        clothinggreen2.value_int = self.clothing_tint2green
         clothinggreen2.link_output(clothingnode, "pfm", "intTint2Green")
 
         clothingblue2 = nodes.new("PlasmaAttribIntNode")
-        clothingblue2.value_int = clothing_tint2blue
+        clothingblue2.value_int = self.clothing_tint2blue
         clothingblue2.link_output(clothingnode, "pfm", "intTint2Blue")
 
+        # Misc
         clothingvis = nodes.new("PlasmaAttribBoolNode")
         clothingvis.value = self.clothing_stayvis
         clothingvis.link_output(clothingnode, "pfm", "boolStayVisible")
@@ -276,4 +290,3 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         clothingeval = nodes.new("PlasmaAttribBoolNode")
         clothingeval.value = False
         clothingeval.link_output(clothingnode, "pfm", "boolFirstUpdate")
-

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -177,33 +177,20 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
     clothing_chance = StringProperty(name="Chance SDL (optional)",
                                      description="SDL variable for chance appearance of clothing.",
                                      options=set())
-    clothing_tint1red = IntProperty(name="Tint 1 Red",
-                                    description="Red setting for first tint.",
-                                    min=0, max=255, default=255,
-                                    options=set())
-    clothing_tint1green = IntProperty(name="Tint 1 Green",
-                                    description="Green setting for first tint.",
-                                    min=0, max=255, default=255,
-                                    options=set())
-    clothing_tint1blue = IntProperty(name="Tint 1 Blue",
-                                    description="Blue setting for first tint.",
-                                    min=0, max=255, default=255,
-                                    options=set())
+    clothing_tint1 = FloatVectorProperty(name="Tint 1",
+                                         description="Sets the default color of the first tint in clothing.",
+                                         subtype="COLOR",
+                                         min=0.0, max=1.0,
+                                         default=(1.0, 1.0, 1.0))
+    clothing_tint2 = FloatVectorProperty(name="Tint 2",
+                                         description="Sets the default color of the second tint in clothing.",
+                                         subtype="COLOR",
+                                         min=0.0, max=1.0,
+                                         default=(1.0, 1.0, 1.0))
     clothing_tint2on = BoolProperty(name="Second Tint?",
                                     description="Does the clothing item have a second tint color?",
                                     default=False,
                                     options=set())
-    clothing_tint2red = IntProperty(name="Tint 2 Red",
-                                    description="Red setting for second tint.",
-                                    min=0, max=255, default=255,
-                                    options=set())
-    clothing_tint2green = IntProperty(name="Tint 2 Green",
-                                    description="Green setting for second tint.",
-                                    min=0, max=255, default=255,
-                                    options=set())
-    clothing_tint2blue = IntProperty(name="Tint 2 Blue",
-                                    description="Blue setting for second tint.",
-                                    min=0, max=255, default=255,
                                     options=set())
     clothing_stayvis = BoolProperty(name="Stay Visible After Click?",
                                     description="Should the clothing stay visible after first clicking?",
@@ -212,6 +199,8 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
 
     def logicwiz(self, bo, tree):
         nodes = tree.nodes
+        colortint1 = self.clothing_tint1
+        colortint2 = self.clothing_tint2
 
         # Create Python File node
         clothingpynode = self._create_python_file_node(tree, clothing_pfm["filename"], clothing_pfm["attribs"])
@@ -257,27 +246,27 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         clothingmale.link_output(clothingpynode, "pfm", "stringMClothingName")
 
         clothingred1 = nodes.new("PlasmaAttribIntNode")
-        clothingred1.value_int = self.clothing_tint1red
+        clothingred1.value_int = (255 * colortint1.r)
         clothingred1.link_output(clothingpynode, "pfm", "intTint1Red")
 
         clothinggreen1 = nodes.new("PlasmaAttribIntNode")
-        clothinggreen1.value_int = self.clothing_tint1green
+        clothinggreen1.value_int = (255 * colortint1.g)
         clothinggreen1.link_output(clothingpynode, "pfm", "intTint1Green")
 
         clothingblue1 = nodes.new("PlasmaAttribIntNode")
-        clothingblue1.value_int = self.clothing_tint1blue
+        clothingblue1.value_int = (255 * colortint1.b)
         clothingblue1.link_output(clothingpynode, "pfm", "intTint1Blue")
 
         clothingred2 = nodes.new("PlasmaAttribIntNode")
-        clothingred2.value_int = self.clothing_tint2red
+        clothingred2.value_int = (255 * colortint2.r)
         clothingred2.link_output(clothingpynode, "pfm", "intTint2Red")
 
         clothinggreen2 = nodes.new("PlasmaAttribIntNode")
-        clothinggreen2.value_int = self.clothing_tint2green
-        clothinggreen2.link_output(clothingypnode, "pfm", "intTint2Green")
+        clothinggreen2.value_int = (255 * colortint2.g)
+        clothinggreen2.link_output(clothingpynode, "pfm", "intTint2Green")
 
         clothingblue2 = nodes.new("PlasmaAttribIntNode")
-        clothingblue2.value_int = self.clothing_tint2blue
+        clothingblue2.value_int = (255 * colortint2.b)
         clothingblue2.link_output(clothingpynode, "pfm", "intTint2Blue")
 
         # Misc

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -119,7 +119,7 @@ class PlasmaMaintainersMarker(PlasmaModifierProperties):
         return True
 
 
-clothing_pfms = {
+clothing_pfm = {
     "filename": "xTakableClothing.py",
     "attribs": (
         { 'id':  1, 'type': "ptAttribString", 'name': "stringVarName" },
@@ -213,16 +213,14 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
     def logicwiz(self, bo, tree):
         nodes = tree.nodes
 
-        clothing_pfm = clothing_pfms
-        clothingnode = self._create_python_file_node(tree, clothing_pfm["filename"], clothing_pfm["attribs"])
-        self._create_clothing_nodes(bo, tree.nodes, clothingnode)
+        # Create Python File node
+        clothingpynode = self._create_python_file_node(tree, clothing_pfm["filename"], clothing_pfm["attribs"])
 
-    def _create_clothing_nodes(self, clickable_object, nodes, clothingnode):
         # Clickable
         clickable = nodes.new("PlasmaClickableNode")
         clickable.clickable_object = self.clickable_object
         clickable.allow_simple = False
-        clickable.link_output(clothingnode, "satisfies", "actClickable")
+        clickable.link_output(clothingpynode, "satisfies", "actClickable")
 
         # Region
         clothingrgn = nodes.new("PlasmaClickableRegionNode")
@@ -232,61 +230,61 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         # SDL Variable
         clothingsdlvar = nodes.new("PlasmaAttribStringNode")
         clothingsdlvar.value = self.clothing_sdl
-        clothingsdlvar.link_output(clothingnode, "pfm", "stringVarName")
+        clothingsdlvar.link_output(clothingpynode, "pfm", "stringVarName")
 
         # Show On True?
         clothingshow = nodes.new("PlasmaAttribBoolNode")
         clothingshow.value = self.clothing_show
-        clothingshow.link_output(clothingnode, "pfm", "boolShowOnTrue")
+        clothingshow.link_output(clothingpynode, "pfm", "boolShowOnTrue")
 
         # Hair color?
         clothinghair = nodes.new("PlasmaAttribBoolNode")
         clothinghair.value = self.clothing_hair
-        clothinghair.link_output(clothingnode, "pfm", "boolHasHairColor")
+        clothinghair.link_output(clothingpynode, "pfm", "boolHasHairColor")
 
         # Chance SDL
         clothingchance = nodes.new("PlasmaAttribStringNode")
         clothingchance.value = self.clothing_chance
-        clothingchance.link_output(clothingnode, "pfm", "stringChanceSDLName")
+        clothingchance.link_output(clothingpynode, "pfm", "stringChanceSDLName")
 
         # Colors, man!
         clothingfemale = nodes.new("PlasmaAttribStringNode")
         clothingfemale.value = self.clothing_female
-        clothingfemale.link_output(clothingnode, "pfm", "stringFClothingName")
+        clothingfemale.link_output(clothingpynode, "pfm", "stringFClothingName")
 
         clothingmale = nodes.new("PlasmaAttribStringNode")
         clothingmale.value = self.clothing_male
-        clothingmale.link_output(clothingnode, "pfm", "stringMClothingName")
+        clothingmale.link_output(clothingpynode, "pfm", "stringMClothingName")
 
         clothingred1 = nodes.new("PlasmaAttribIntNode")
         clothingred1.value_int = self.clothing_tint1red
-        clothingred1.link_output(clothingnode, "pfm", "intTint1Red")
+        clothingred1.link_output(clothingpynode, "pfm", "intTint1Red")
 
         clothinggreen1 = nodes.new("PlasmaAttribIntNode")
         clothinggreen1.value_int = self.clothing_tint1green
-        clothinggreen1.link_output(clothingnode, "pfm", "intTint1Green")
+        clothinggreen1.link_output(clothingpynode, "pfm", "intTint1Green")
 
         clothingblue1 = nodes.new("PlasmaAttribIntNode")
         clothingblue1.value_int = self.clothing_tint1blue
-        clothingblue1.link_output(clothingnode, "pfm", "intTint1Blue")
+        clothingblue1.link_output(clothingpynode, "pfm", "intTint1Blue")
 
         clothingred2 = nodes.new("PlasmaAttribIntNode")
         clothingred2.value_int = self.clothing_tint2red
-        clothingred2.link_output(clothingnode, "pfm", "intTint2Red")
+        clothingred2.link_output(clothingpynode, "pfm", "intTint2Red")
 
         clothinggreen2 = nodes.new("PlasmaAttribIntNode")
         clothinggreen2.value_int = self.clothing_tint2green
-        clothinggreen2.link_output(clothingnode, "pfm", "intTint2Green")
+        clothinggreen2.link_output(clothingypnode, "pfm", "intTint2Green")
 
         clothingblue2 = nodes.new("PlasmaAttribIntNode")
         clothingblue2.value_int = self.clothing_tint2blue
-        clothingblue2.link_output(clothingnode, "pfm", "intTint2Blue")
+        clothingblue2.link_output(clothingpynode, "pfm", "intTint2Blue")
 
         # Misc
         clothingvis = nodes.new("PlasmaAttribBoolNode")
         clothingvis.value = self.clothing_stayvis
-        clothingvis.link_output(clothingnode, "pfm", "boolStayVisible")
+        clothingvis.link_output(clothingpynode, "pfm", "boolStayVisible")
 
         clothingeval = nodes.new("PlasmaAttribBoolNode")
         clothingeval.value = False
-        clothingeval.link_output(clothingnode, "pfm", "boolFirstUpdate")
+        clothingeval.link_output(clothingpynode, "pfm", "boolFirstUpdate")

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -213,9 +213,9 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
 
         clothing_pfm = clothing_pfms
         clothingnode = self._create_python_file_node(tree, clothing_pfm["filename"], clothing_pfm["attribs"])
-        self._create_clothing_nodes(bo, tree.nodes, imagernode)
+        self._create_clothing_nodes(bo, tree.nodes, clothingnode)
 
-    def _create_clothing_node(self, clickable_object, nodes, clothingnode):
+    def _create_clothing_nodes(self, clickable_object, nodes, clothingnode):
         # Clickable
         clickable = nodes.new("PlasmaClickableNode")
         clickable.clickable_object = self.clickable_object

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -203,7 +203,8 @@ class PlasmaTakeClothing(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         # Clickable
         clickable = nodes.new("PlasmaClickableNode")
         clickable.clickable_object = self.clickable_object
-        clickable.allow_simple = False
+        for i in clickable.inputs:
+            i.allow_simple = False
         clickable.link_output(clothingpynode, "satisfies", "actClickable")
 
         # Region

--- a/korman/ui/modifiers/logic.py
+++ b/korman/ui/modifiers/logic.py
@@ -42,3 +42,41 @@ def spawnpoint(modifier, layout, context):
 def maintainersmarker(modifier, layout, context):
     layout.label(text="Positive Y is North, positive Z is up.")
     layout.prop(modifier, "calibration")
+
+def clothing(modifier, layout, context):
+    layout.prop(modifier, "clickable_object")
+    layout.prop(modifier, "clickable_region")
+
+    if modifier.clickable_object and modifier.clickable_region:
+        layout.separator()
+        layout.label(text="Clothing Item Details:")
+        split = layout.split()
+        col = split.column()
+        col.prop(modifier, "clothing_sdl")
+        col.prop(modifier, "clothing_chance")
+        col.prop(modifier, "clothing_female")
+        col.prop(modifier, "clothing_male")
+
+        layout.separator()
+        layout.label(text="Default Clothing Color(s):")
+        layout.prop(modifier, "clothing_tint2on")
+        split = layout.split()
+        col = split.column()
+        col.prop(modifier, "clothing_tint1red")
+        col.prop(modifier, "clothing_tint1green")
+        col.prop(modifier, "clothing_tint1blue")
+
+        col = split.column()
+        col.enabled = modifier.clothing_tint2on is True
+        col.prop(modifier, "clothing_tint2red")
+        col.prop(modifier, "clothing_tint2green")
+        col.prop(modifier, "clothing_tint2blue")
+
+        layout.separator()
+        layout.label(text="Visibility:")
+        split = layout.split()
+        col = split.column()
+        col.prop(modifier, "clothing_show")
+
+        col = split.column()
+        col.prop(modifier, "clothing_stayvis")

--- a/korman/ui/modifiers/logic.py
+++ b/korman/ui/modifiers/logic.py
@@ -59,7 +59,13 @@ def clothing(modifier, layout, context):
 
         layout.separator()
         layout.label(text="Default Clothing Color(s):")
-        layout.prop(modifier, "clothing_tint2on")
+        split = layout.split()
+        col = split.column()
+        col.prop(modifier, "clothing_tint2on")
+
+        col = split.column()
+        col.prop(modifier, "clothing_hair")
+
         split = layout.split()
         col = split.column()
         col.prop(modifier, "clothing_tint1red")

--- a/korman/ui/modifiers/logic.py
+++ b/korman/ui/modifiers/logic.py
@@ -61,18 +61,14 @@ def clothing(modifier, layout, context):
         layout.label(text="Default Clothing Color(s):")
         split = layout.split()
         col = split.column()
-        col.prop(modifier, "clothing_tint2on")
-
-        col = split.column()
-        col.prop(modifier, "clothing_hair")
-
-        split = layout.split()
-        col = split.column()
         col.prop(modifier, "clothing_tint1")
 
         col = split.column()
-        col.enabled = modifier.clothing_tint2on is True
         col.prop(modifier, "clothing_tint2")
+
+        split = layout.split()
+        col = split.column()
+        col.prop(modifier, "clothing_hair")
 
         layout.separator()
         layout.label(text="Visibility:")

--- a/korman/ui/modifiers/logic.py
+++ b/korman/ui/modifiers/logic.py
@@ -68,15 +68,11 @@ def clothing(modifier, layout, context):
 
         split = layout.split()
         col = split.column()
-        col.prop(modifier, "clothing_tint1red")
-        col.prop(modifier, "clothing_tint1green")
-        col.prop(modifier, "clothing_tint1blue")
+        col.prop(modifier, "clothing_tint1")
 
         col = split.column()
         col.enabled = modifier.clothing_tint2on is True
-        col.prop(modifier, "clothing_tint2red")
-        col.prop(modifier, "clothing_tint2green")
-        col.prop(modifier, "clothing_tint2blue")
+        col.prop(modifier, "clothing_tint2")
 
         layout.separator()
         layout.label(text="Visibility:")


### PR DESCRIPTION
* Adds properties and UI for a potential clothing clickable mod that uses xTakableClothing.py

Note that this does *not* add the actual clothing item for the avatar to GlobalClothing, but will set up a clickable in an Age to utilize an existing one (or new one if it's been added otherwise).