### PR TITLE
Bump to B4K 2022-11-13.

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -11,14 +11,14 @@ jobs:
               generator: Visual Studio 17 2022,
               arch: Win32,
               str: windows-x86,
-              blender-url: "https://github.com/Hoikas/blender2.7/releases/download/blender2.79_20220528/blender-2.79.0-git20220528.f2969d58b0dc-windows32.zip",
+              blender-url: "https://github.com/Hoikas/blender2.7/releases/download/blender2.79_20221113/blender-2.79.0-git20221114.f970f178c093-windows32.zip",
             }
           - {
               os: windows-2022,
               generator: Visual Studio 17 2022,
               arch: x64,
               str: windows-x64,
-              blender-url: "https://github.com/Hoikas/blender2.7/releases/download/blender2.79_20220528/blender-2.79.0-git20220528.f2969d58b0dc-windows64.zip",
+              blender-url: "https://github.com/Hoikas/blender2.7/releases/download/blender2.79_20221113/blender-2.79.0-git20221114.f970f178c093-windows64.zip",
             }
 
     env:


### PR DESCRIPTION
This revision of B4K re-enabled the Cycles Renderer, which was disabled due to a bug in MSVC when B4K was previously rebuilt for a critical bug fix.