### PR TITLE
Re-fix the TPotS launching race condition.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -208,7 +208,7 @@ if(korman_BUILD_HSPLASMA)
     korman_add_external_project(HSPlasma
         GIT_REPOSITORY "https://github.com/H-uru/libhsplasma.git"
         # Be sure to increase this as the feature set used by Korman increases
-        GIT_TAG 4a1fd38dca471008de62209cc89616351161a843
+        GIT_TAG 6fa56d979163af8602cd6212449a07400a14b532
         # We can only do shallow checkouts if the above is a branch or tag.
         GIT_SHALLOW FALSE
         CMAKE_CACHE_ARGS


### PR DESCRIPTION
Recap: There is a bug in Windows where file IO with the C apis can race if the operations occur in separate processes. This means that sometimes the TPotS auto-linking feature would link you to the wrong Age due to reading an old/cached copy of the vault file.

This was fixed in H-uru/libhsplasma#242 originally, but Win32 APIs seem to have terrible performance without user mode buffering, which negatively impacted PRP loading in other tools, such as PRP Shop. Therefore, the fix was reverted in H-uru/libhsplasma#246. This fixes the race condition closer to the point of impact using the Win32 stream introduced by H-uru/libhsplasma#264.

This is a draft until H-uru/libhsplasma#264 is accepted.