### PR TITLE
Add Quality modifier to provide load masks

### DIFF
--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -969,3 +969,59 @@ class PlasmaVisibilitySet(PlasmaModifierProperties):
             if not region.control_region:
                 raise ExportError("{}: Not all Visibility Controls are set up properly in Visibility Set".format(bo.name))
             addRegion(exporter.mgr.find_create_key(plVisRegion, bl=region.control_region))
+
+class PlasmaQualityLevels(bpy.types.PropertyGroup):
+    low = BoolProperty(name="Low Quality",
+                       description="Object renders at low quality graphics level",
+                       default=False,
+                       options=set())
+
+    mid = BoolProperty(name="Medium Quality",
+                       description="Object renders at medium quality graphics level",
+                       default=False,
+                       options=set())
+
+    high = BoolProperty(name="High Quality",
+                        description="Object renders at high quality graphics level",
+                        default=False,
+                        options=set())
+
+    ultra = BoolProperty(name="Ultra Quality",
+                         description="Object renders at ultra quality graphics level",
+                         default=False,
+                         options=set())
+
+    @property
+    def mask_value(self):
+        q = 0
+
+        if self.low:
+            q |= (1 << 0)
+
+        if self.mid:
+            q |= (1 << 1)
+
+        if self.high:
+            q |= (1 << 2)
+
+        if self.ultra:
+            q |= (1 << 3)
+
+        return q
+
+
+class PlasmaQualityMod(PlasmaModifierProperties):
+    pl_id = "qualitymod"
+
+    bl_category = "Render"
+    bl_label = "Quality Levels"
+    bl_description = "Defines the quality levels at which this object is visible"
+
+    cap_minimal = PointerProperty(type=PlasmaQualityLevels)
+    cap_shaders = PointerProperty(type=PlasmaQualityLevels)
+
+    def export(self, exporter, bo, so):
+        low = 0xf0 | self.cap_minimal.mask_value
+        high = 0xf0 | self.cap_shaders.mask_value
+
+        so.key.mask = (high << 8) | (low)

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -328,3 +328,21 @@ def visregion(modifier, layout, context):
 
     # Other settings
     layout.prop(modifier, "replace_normal")
+
+def qualitymod(modifier, layout, context):
+    split = layout.split()
+    col = split.column()
+    col.label("Without shader support:")
+    box = col.box()
+    box.prop(modifier.cap_minimal, "low")
+    box.prop(modifier.cap_minimal, "mid")
+    box.prop(modifier.cap_minimal, "high")
+    box.prop(modifier.cap_minimal, "ultra")
+
+    col = split.column()
+    col.label("With shader support:")
+    box = col.box()
+    box.prop(modifier.cap_shaders, "low")
+    box.prop(modifier.cap_shaders, "mid")
+    box.prop(modifier.cap_shaders, "high")
+    box.prop(modifier.cap_shaders, "ultra")


### PR DESCRIPTION
This allows Age builder control over what quality levels objects are rendered at. This does not (yet) automatically hook up load masks for things like wavesets or grass shader mods, but provides a general quality modifier.

![Screenshot from 2023-01-28 00-09-35](https://user-images.githubusercontent.com/241708/215255352-46cc40cc-8e79-4954-84be-f8bf1006bf31.png)


Related to #356.