### PR TITLE
Fix `TypeError` in outfile warning message.

### DIFF
--- a/korman/exporter/outfile.py
+++ b/korman/exporter/outfile.py
@@ -20,7 +20,7 @@ import json
 from .. import korlib
 import locale
 import os
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePath, PureWindowsPath
 from ..plasma_magic import plasma_python_glue
 from PyHSPlasma import *
 import shutil
@@ -392,7 +392,7 @@ class OutputFiles:
                     shutil.copy2(i.file_path, dst_path)
             else:
                 report.warn("No data found for dependency file '{}'. It will not be copied into the export directory.",
-                            str(i.dirname / i.filename), indent=1)
+                            PurePath(i.dirname, i.filename), indent=1)
 
     def _write_gather_build(self):
         report = self._exporter().report


### PR DESCRIPTION
These attributes are strings, not paths. It is safe to format with a path -- paths are implicitly convertible to strings by formatters. We use a `PurePath` because we only care about getting the string name and not actually performing any path manipulation.

CC @ Traveler263 please try this fix.

Fixes #361 