### PR TITLE
Improve handling of `ptAttribNamedResponder`.

### DIFF
--- a/korman/nodes/node_core.py
+++ b/korman/nodes/node_core.py
@@ -83,6 +83,14 @@ class PlasmaNodeBase:
                                            kwargs.get("so"))
         return exporter.mgr.find_create_key(pClass, **kwargs)
 
+    def _find_key(self, pClass, exporter, **kwargs):
+        """Finds a plKey specific to this node."""
+        assert "name" not in kwargs
+        kwargs["name"] = self.get_key_name(issubclass(pClass, (plObjInterface, plSingleModifier)),
+                                           kwargs.pop("suffix", ""), kwargs.get("bl"),
+                                           kwargs.get("so"))
+        return exporter.mgr.find_key(pClass, **kwargs)
+
     def find_input(self, key, idname=None):
         for i in self.inputs:
             if i.alias == key:


### PR DESCRIPTION
When a responder node is linked to a Python file node's ptAttribNamedResponder socket, it will now export with the same name as the node itself. In that way, the responder can be addressed in the attribute's value mapping in the Python script itself.

Closes #346.

CC @DoobesURU for verification.