### PR TITLE
Don't try to sort with `None`.

### DIFF
--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -893,6 +893,7 @@ class PlasmaSoundMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacksNo
     def has_callbacks(self):
         if not self.is_random_sound:
             return self.event != "NONE"
+        return False
 
     @classmethod
     def _idprop_mapping(cls):

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -356,7 +356,7 @@ class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
         """
         if node is None:
             node = self
-        return sorted(node.find_outputs("msgs"), key=lambda x: x.has_callbacks and x.has_linked_callbacks)
+        return sorted(node.find_outputs("msgs"), key=lambda x: bool(x.has_callbacks and x.has_linked_callbacks))
 
 
 class PlasmaRespStateSocket(PlasmaNodeSocketBase, bpy.types.NodeSocket):


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "D:\Korman 0.14\2.79\scripts\addons\korman\operators\op_export.py", line 228, in execute
    e.run()
  File "D:\Korman 0.14\2.79\scripts\addons\korman\exporter\convert.py", line 118, in run
    self._export_referenced_node_trees()
  File "D:\Korman 0.14\2.79\scripts\addons\korman\exporter\convert.py", line 336, in _export_referenced_node_trees
    tree.export(self, bo, so)
  File "D:\Korman 0.14\2.79\scripts\addons\korman\nodes\node_core.py", line 503, in export
    node.export(exporter, bo, so)
  File "D:\Korman 0.14\2.79\scripts\addons\korman\nodes\node_responder.py", line 136, in export
    stateMgr.convert_states(exporter, so)
  File "D:\Korman 0.14\2.79\scripts\addons\korman\nodes\node_responder.py", line 113, in convert_states
    node.convert_state(exporter, so, state, i, self)
  File "D:\Korman 0.14\2.79\scripts\addons\korman\nodes\node_responder.py", line 297, in convert_state
    self._generate_command(exporter, so, stateMgr.responder, commands, i)
  File "D:\Korman 0.14\2.79\scripts\addons\korman\nodes\node_responder.py", line 351, in _generate_command
    self._generate_command(exporter, so, responder, commandMgr, i, childWaitOn)
  File "D:\Korman 0.14\2.79\scripts\addons\korman\nodes\node_responder.py", line 351, in _generate_command
    self._generate_command(exporter, so, responder, commandMgr, i, childWaitOn)
  File "D:\Korman 0.14\2.79\scripts\addons\korman\nodes\node_responder.py", line 350, in _generate_command
    for i in self._get_child_messages(msgNode):
  File "D:\Korman 0.14\2.79\scripts\addons\korman\nodes\node_responder.py", line 359, in _get_child_messages
    return sorted(node.find_outputs("msgs"), key=lambda x: x.has_callbacks and x.has_linked_callbacks)
TypeError: '<' not supported between instances of 'bool' and 'NoneType'
```