### PR TITLE
Fix incorrect pretends-to-be-a semantics from #367.

### DIFF
--- a/korman/exporter/utils.py
+++ b/korman/exporter/utils.py
@@ -85,6 +85,18 @@ class BMeshObject:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._obj, name)
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        # NOTE: Calling `hasattr()` will trigger infinite recursion in __getattr__(), so
+        # check the object dict itself for anything that we want on this instance.
+        d = self.__dict__
+        if name not in d:
+            obj = d.get("_obj")
+            if obj is not None:
+                if hasattr(obj, name):
+                    setattr(obj, name, value)
+                    return
+        super().__setattr__(name, value)
+
     @property
     def object(self) -> bpy.types.Object:
         return self._obj

--- a/korman/operators/op_mesh.py
+++ b/korman/operators/op_mesh.py
@@ -103,7 +103,7 @@ class PlasmaAddFlareOperator(PlasmaMeshOperator, bpy.types.Operator):
         flare_plane = utils.BMeshObject(f"{self.name_stem}_Visible", managed=False)
         flare_plane.hide_render = True
         flare_plane.plasma_object.enabled = True
-        bpyscene.objects.active = flare_plane
+        bpyscene.objects.active = flare_plane.object
         with flare_plane as bm:
             # Make the actual plane mesh, facing away from the empty
             bmesh.ops.create_grid(bm, size=(0.5 + self.flare_distance * 0.5), matrix=mathutils.Matrix.Rotation(math.radians(180.0), 4, 'X'))


### PR DESCRIPTION
This fixes review comments left on #367 that were caused by missing pretends-to-be-a semantics. `BMeshObject` is intended to provide pass-through access to `bpy.types.Object`'s attributes.

Supercedes and closes #369.