### PR TITLE
Fix #376

### DIFF
--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -159,9 +159,14 @@ class ExportManager:
             pfm.filename = replace_python2_identifier(age)
 
         # Textures.prp
-        # FIXME: unconditional creation will overwrite any existing textures PRP. This should
-        # be addressed by a successful implementation of #145.
-        self.create_page(age, "Textures", -1, builtin=True)
+        # TODO: #145 load any already existing Textures PRP and resave it.
+        if bpy.context.scene.world.plasma_age.use_texture_page:
+            self.create_page(age, "Textures", -1, builtin=True)
+        elif self.getVer() <= pvPots:
+            self._exporter().report.warn(
+                "No textures page was created - be sure this Age has one "
+                "or the game may crash!"
+            )
 
     def create_page(self, age, name, id, *, builtin=False, external=False):
         location = plLocation(self.mgr.getVer())
@@ -328,10 +333,9 @@ class ExportManager:
     def get_textures_page(self, key: plKey) -> plLocation:
         """Gets the appropriate page for a texture for a given plLayer"""
         # The point of this is to account for per-page textures...
-        if bpy.context.scene.world.plasma_age.use_texture_page:
-            return self._pages["Textures"]
-        else:
+        if not bpy.context.scene.world.plasma_age.use_texture_page:
             return key.location
+        return self._pages.get("Textures", key.location)
 
     def _pack_agesdl_hook(self, age):
         output = self._exporter().output

--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -151,12 +151,13 @@ class ExportManager:
         #          present and valid. They do not have to have any contents. See AvatarCustomization.
         # BuiltIn.prp
         want_pysdl = bpy.context.scene.world.plasma_age.age_sdl
-        builtin = self.create_page(age, "BuiltIn", -2, builtin=True)
-        if want_pysdl:
-            self._pack_agesdl_hook(age)
-            sdl = self.add_object(plSceneObject, name="AgeSDLHook", loc=builtin)
-            pfm = self.add_object(plPythonFileMod, name="VeryVerySpecialPythonFileMod", so=sdl)
-            pfm.filename = replace_python2_identifier(age)
+        if self.getVer() <= pvPots or want_pysdl:
+            builtin = self.create_page(age, "BuiltIn", -2, builtin=True)
+            if want_pysdl:
+                self._pack_agesdl_hook(age)
+                sdl = self.add_object(plSceneObject, name="AgeSDLHook", loc=builtin)
+                pfm = self.add_object(plPythonFileMod, name="VeryVerySpecialPythonFileMod", so=sdl)
+                pfm.filename = replace_python2_identifier(age)
 
         # Textures.prp
         # TODO: #145 load any already existing Textures PRP and resave it.


### PR DESCRIPTION
Fixes #376 by not creating a Textures.prp if the textures page is not requested. Also, as a bonus, empty BuiltIn.prp files are not created on MOUL. Note that TPotS expects for all Ages to have a Textures.prp and BuiltIn.prp - Korman will now warn when exporting for TPotS without Textures.prp enabled.

CC @Hazado @Deledrius 