### PR TITLE
Fix #391.

### DIFF
--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -401,7 +401,6 @@ class PlasmaGameGuiDialogModifier(PlasmaModifierProperties, _GameGuiMixin):
     bl_category = "GUI"
     bl_label = "GUI Dialog (ex)"
     bl_description = "XXX"
-    bl_object_types = {"FONT", "MESH"}
 
     camera_object: bpy.types.Object = PointerProperty(
         name="GUI Camera",


### PR DESCRIPTION
GUI Dialog Mods don't require any particular object type - they're just hints about what's going on with the GUI. Limiting them to meshes actually breaks the Note Popup modifier, which attaches a GUI Dialog modifier to an empty.

CC @DoobesURU 

Fixes #391.