### PR TITLE
Pay down some technical debt wrt cube regions.

### DIFF
--- a/korman/exporter/utils.py
+++ b/korman/exporter/utils.py
@@ -140,19 +140,6 @@ def create_cube_region(name: str, size: float, owner_object: bpy.types.Object) -
     return region_object.release()
 
 @contextmanager
-def pre_export_optional_cube_region(source, attr: str, name: str, size: float, owner_object: bpy.types.Object) -> Optional[bpy.types.Object]:
-    if getattr(source, attr) is None:
-        region_object = create_cube_region(name, size, owner_object)
-        setattr(source, attr, region_object)
-        try:
-            yield region_object
-        finally:
-            source.property_unset(attr)
-    else:
-        # contextlib.contextmanager requires for us to yield. Sad.
-        yield
-
-@contextmanager
 def temporary_camera_object(scene: bpy.types.Scene, name: str) -> bpy.types.Object:
     try:
         cam_data = bpy.data.cameras.new(name)

--- a/korman/properties/modifiers/gui.py
+++ b/korman/properties/modifiers/gui.py
@@ -235,10 +235,11 @@ class PlasmaJournalBookModifier(PlasmaModifierProperties, PlasmaModifierLogicWiz
             return
 
         # Generate the clickable region if it was not provided
-        yield utils.pre_export_optional_cube_region(
-            self, "clickable_region",
-            f"{bo.name}_Journal_ClkRgn", 6.0, bo
-        )
+        if self.clickable_region is None:
+            self.clickable_region = yield utils.create_cube_region(
+                f"{bo.name}_Journal_ClkRgn", 6.0,
+                bo
+            )
 
         # Generate the logic nodes
         yield self.convert_logic(bo, age_name=exporter.age_name, version=version)
@@ -471,16 +472,15 @@ class PlasmaLinkingBookModifier(PlasmaModifierProperties, PlasmaModifierLogicWiz
             return
 
         # Auto-generate a six-foot cube region around the clickable if none was provided.
-        yield utils.pre_export_optional_cube_region(
-            self, "clickable_region",
-            f"{self.key_name}_LinkingBook_ClkRgn", 6.0,
-            self.clickable
-        )
+        if self.clickable_region is None:
+            self.clickable_region = yield utils.create_cube_region(
+                f"{self.key_name}_LinkingBook_ClkRgn", 6.0,
+                self.clickable
+            )
 
         # Auto-generate a ten-foot cube region around the clickable if none was provided.
-        if self.shareable:
-            yield utils.pre_export_optional_cube_region(
-                self, "share_region",
+        if self.shareable and self.share_region is None:
+            self.share_region = yield utils.create_cube_region(
                 f"{self.key_name}_LinkingBook_ShareRgn", 10.0,
                 self.clickable
             )
@@ -816,8 +816,8 @@ class PlasmaNotePopupModifier(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         click_plane_object.plasma_modifiers.gui_control.tag_id = 99
 
         # Auto-generate a six-foot cube region around the clickable if none was provided.
-        yield utils.pre_export_optional_cube_region(
-            self, "clickable_region",
+        if self.clickable_region is None:
+            self.clickable_region = yield utils.create_cube_region(
             f"{self.key_name}_DialogToggle_ClkRgn", 6.0,
             self.clickable_object
         )

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -160,11 +160,11 @@ class PlasmaTelescope(PlasmaModifierProperties, PlasmaModifierLogicWiz):
 
     def pre_export(self, exporter, bo):
         # Generate a six-foot cube region if none was provided.
-        yield utils.pre_export_optional_cube_region(
-            self, "clickable_region",
-            f"{self.key_name}_Telescope_ClkRgn", 6.0,
-            bo
-        )
+        if self.clickable_region is None:
+            self.clickable_region = yield utils.create_cube_region(
+                f"{self.key_name}_Telescope_ClkRgn", 6.0,
+                bo
+            )
 
         # Generate the logic nodes
         yield self.convert_logic(bo)


### PR DESCRIPTION
the `pre_export_optional_cube_region` function is a decent idea, but it predates the ability to do things like `foo = yield bar()` in `pre_export()` generator methods. So, we remove it in favor of yielding and assigning in one line. This should clean up some noisy warnings from Blender after the export is over.