### PR TITLE
Entry Cameras for the Spawn Point Modifier

### DIFF
--- a/korman/exporter/utils.py
+++ b/korman/exporter/utils.py
@@ -150,6 +150,7 @@ def create_box_region(
     with region_object as bm:
         center = owner_object.matrix_world.translation
         if origin == RegionOrigin.bottom:
+            center = center.copy()
             center.z += size.z * 0.5
         vert_src = [
             (center.x + size.x * 0.5, center.y + size.y * 0.5, center.z + size.z * 0.5),

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -133,7 +133,7 @@ class PlasmaSpawnPoint(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         if self.exit_region is None:
             self.exit_region = yield utils.create_cube_region(
                 f"{self.key_name}_ExitRgn", 6.0,
-                bo, utils.CubeRegionOrigin.bottom
+                bo, utils.RegionOrigin.bottom
             )
 
         yield self.convert_logic(bo)

--- a/korman/ui/modifiers/logic.py
+++ b/korman/ui/modifiers/logic.py
@@ -13,7 +13,14 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import bpy
+
+from typing import *
+
+if TYPE_CHECKING:
+    from ...properties.modifiers.logic import *
 
 from .. import ui_list
 
@@ -36,8 +43,18 @@ def advanced_logic(modifier, layout, context):
         layout.row().prop_menu_enum(logic, "version")
         layout.prop(logic, "node_tree", icon="NODETREE")
 
-def spawnpoint(modifier, layout, context):
+def spawnpoint(modifier: PlasmaSpawnPoint, layout, context):
     layout.label(text="Avatar faces negative Y.")
+    layout.separator()
+
+    col = layout.column()
+    col.prop(modifier, "entry_camera", icon="CAMERA_DATA")
+    sub = col.row()
+    sub.active = modifier.entry_camera is not None
+    sub.prop(modifier, "exit_region", icon="MESH_DATA")
+    sub = col.row()
+    sub.active = modifier.entry_camera is not None and modifier.exit_region is not None
+    sub.prop(modifier, "bounds_type")
 
 def maintainersmarker(modifier, layout, context):
     layout.label(text="Positive Y is North, positive Z is up.")


### PR DESCRIPTION
This simplies the creation of "entry cameras" as seen in Doobes' Ages Veelay and Chiso. In Doobes' Ages, the entry cameras are pushed by entering into a region around the spawn point. When exiting the region, the camera is popped off and the region is disabled. Unfortunately, since this is a general purpose modifier, we cannot simply use that approach. That approach assumes there is a single spawn point for the entire Age. If you were to enter a second spawn point, then walk intgo the other spawn point's entry camera region, it would be spuriously triggered. Therefore, I have written a new `xEntryCam.py` script for CWE to ensure that all entry cameras are disabled when the local player finishes linking in.

See H-uru/Plasma#1556