### PR TITLE
Improve vertex color exporting significantly.

### DIFF
--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -504,8 +504,13 @@ class MeshConverter(_MeshManager):
                     normal = source.normal if use_smooth else tessface.normal
 
                     # MOUL/DX9 craps its pants if any element of the normal is exactly 0.0
-                    normal = map(lambda x: max(x, 0.01) if x >= 0.0 else min(x, -0.01), normal)
-                    normal = hsVector3(*normal)
+                    # Profiling indicates that unrolling this would give a performance penalty
+                    # of roughly. Note: unrolling this calculation gives a 43% speedup.
+                    normal = hsVector3(
+                        max(normal[0], 0.01) if normal[0] >= 0.0 else min(normal[0], -0.01),
+                        max(normal[1], 0.01) if normal[1] >= 0.0 else min(normal[1], -0.01),
+                        max(normal[2], 0.01) if normal[2] >= 0.0 else min(normal[2], -0.01),
+                    )
                     normal.normalize()
                     geoVertex.normal = normal
 

--- a/korman/properties/modifiers/water.py
+++ b/korman/properties/modifiers/water.py
@@ -242,6 +242,11 @@ class PlasmaWaterModifier(idprops.IDPropMixin, PlasmaModifierProperties, bpy.typ
     def copy_material(self):
         return True
 
+    def sanity_check(self):
+        vertex_color_layers = frozenset((i.name.lower() for i in self.id_data.data.vertex_colors))
+        if {"col", "color", "colour"} in vertex_color_layers:
+            raise ExportError(f"[{self.id_data.name}] Water modifiers cannot use vertex color lighting")
+
     def export(self, exporter, bo, so):
         waveset = exporter.mgr.find_create_object(plWaveSet7, name=bo.name, so=so)
         if self.wind_object:


### PR DESCRIPTION
This moves the piece-by-piece assembly of vertex colors from `_export_geometry()` into a one-stop-shop for getting the near final vertex colors as Blender knows them. Included in this is separating out the adjustment channels for wavesets - which are stuffed inside of vertex colors. It is now an error for a waveset to have a "col", "color", or "colour" vertex color layer. This is to prevent confusion. Wavesets now accept alpha (red), specularity (green), fresnel (blue), and edgelength (alpha) vertex color layers. The color values in these layers is averaged and output to the respective channels. Further, a default value for edgelength is now computed similar (but not exactly like) PlasmaMax's `SetWaterColor()` function. Artist input to the edgelength vertex color layer will modulate Korman's calculation.

CC @DoobesURU to verify nothing breaks and that waveset vertex alpha should now function as expected.

This is still a draft because I would like to do a pass over eliminating list comprehensions in the tight inner loop of `_export_geometry()`. Until Python 3.12, list comprehensions are actually implemented as function calls. I see 1 comprehension for every face and 1 comprehension for every vertex (!!!), which are major targets for performance optimization.