### PR TITLE
Lightmap AND Vertex Color Option

### DIFF
--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -384,7 +384,7 @@ class MeshConverter(_MeshManager):
 
         # Locate relevant vertex color layers now...
         lm = bo.plasma_modifiers.lightmap
-        color = None if lm.bake_lightmap else self._find_vtx_color_layer(mesh.tessface_vertex_colors)
+        color = None if lm.bake_lightmap and lm.bake_type == "lightmap" else self._find_vtx_color_layer(mesh.tessface_vertex_colors)
         alpha = self._find_vtx_alpha_layer(mesh.tessface_vertex_colors)
 
         # Convert Blender faces into things we can stuff into libHSPlasma

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -430,6 +430,7 @@ class PlasmaLightMapGen(idprops.IDPropMixin, PlasmaModifierProperties, PlasmaMod
                              items=[
                                 ("lightmap", "Lightmap Texture", "Bakes lighting to a lightmap texture"),
                                 ("vcol", "Vertex Colors", "Bakes lighting to vertex colors"),
+                                ("lmandvcol", "Lightmap with Vertex Colors", "Bakes both a lightmap and vertex colors")
                              ],
                              options=set())
 
@@ -465,6 +466,8 @@ class PlasmaLightMapGen(idprops.IDPropMixin, PlasmaModifierProperties, PlasmaMod
                 return True
             elif self.bake_type == "lightmap" and age.lighting_method == "bake":
                 return True
+            elif self.bake_type == "lmandvcol" and age.lighting_method == "bake":
+                return True
             else:
                 return False
         else:
@@ -475,7 +478,7 @@ class PlasmaLightMapGen(idprops.IDPropMixin, PlasmaModifierProperties, PlasmaMod
         return self.bake_lightmap
 
     def export(self, exporter, bo, so):
-        # If we're exporting vertex colors, who gives a rat's behind?
+        # If we're exporting *only* vertex colors, who gives a rat's behind?
         if not self.bake_lightmap:
             return
 

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -224,10 +224,10 @@ def lighting(modifier, layout, context):
 
 def lightmap(modifier, layout, context):
     pl_scene = context.scene.plasma_scene
-    is_texture = modifier.bake_type == "lightmap"
+    is_texture = modifier.bake_type == "lightmap" or modifier.bake_type == "lmandvcol"
 
     layout.prop(modifier, "bake_type")
-    if modifier.bake_type == "vcol":
+    if modifier.bake_type == "vcol" or modifier.bake_type == "lmandvcol":
         col_layer = next((i for i in modifier.id_data.data.vertex_colors if i.name.lower() in _VERTEX_COLOR_LAYERS), None)
         if col_layer is not None:
             layout.label("Mesh color layer '{}' will override this lighting.".format(col_layer.name), icon="ERROR")


### PR DESCRIPTION
Adds an option in the drop-down menu to use both a lightmap _and_ a vertex color layer in the Bake Lighting modifier. This is used in certain instances such as the floor of the outer chamber of the private rooms in the hoods and Kirel.

This has worked in at least two instances, namely the aforementioned private room floor in Kirel and in the common library's interior top floor in Ae'gura.