### PR TITLE
Fix syntax warning about assert

### DIFF
--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -538,10 +538,9 @@ class Exporter:
                     # my_object.foo = bar
                     # ```
                     pre_result = proc(self, bo)
-                    assert (
-                        inspect.isgenerator(pre_result) or pre_result is None,
+                    assert \
+                        inspect.isgenerator(pre_result) or pre_result is None, \
                         "pre_export() should return a generator or None"
-                    )
                     try:
                         gen_result = None
                         while pre_result is not None:


### PR DESCRIPTION
> SyntaxWarning: assertion is always true, perhaps remove parentheses?

`assert` is a keyword, not a function, and using it with parentheses ends up being interpreted as a tuple argument (truthy) rather than a boolean assertion and a message