### PR TITLE
Bounds and Animation Property Deduplication

### DIFF
--- a/korman/enum_props.py
+++ b/korman/enum_props.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from bpy.props import *
 
 from typing import *
+import warnings
 
 # These are the kinds of physical bounds Plasma can work with.
 # This sequence is acceptable in any EnumProperty
@@ -54,9 +55,53 @@ def bounds(physics_attr: Optional[str] = None, store_on_collider: bool = True, *
     if store_on_collider:
         kwargs["get"] = _get_bounds(physics_attr)
         kwargs["set"] = _set_bounds(physics_attr)
+    else:
+        warnings.warn("Storing bounds properties outside of the collision modifier is deprecated.", category=DeprecationWarning)
     if "default" not in kwargs:
         kwargs["default"] = "hull"
     return EnumProperty(
         items=_bounds_types,
         **kwargs
     )
+
+def upgrade_bounds(bl, bounds_attr: str) -> None:
+    # Only perform this process if the property has a value. Otherwise, we'll
+    # wind up blowing away the collision modifier's settings with nonsense.
+    if not bl.is_property_set(bounds_attr):
+        return
+
+    # Before we unregister anything, grab a copy of what the collision modifier currently thinks.
+    bounds_value_curr = getattr(bl, bounds_attr)
+
+    # So, here's the deal. If someone has been playing with nodes and changed the bounds type,
+    # Blender will think the property has been set, even if they wound up with the property
+    # at the default value. I don't know that we can really trust the default in the property
+    # definition to be the same as the old default (they shouldn't be different, but let's be safe).
+    # So, let's apply rough justice. If the destination property thinks it's a triangle mesh, we
+    # don't need to blow that away - it's a very specific non default setting.
+    if bounds_value_curr == "trimesh":
+        return
+
+    # Unregister the new/correct proxy bounds property (with getter/setter) and re-register
+    # the property without the proxy functions to get the old value. Reregister the new property
+    # again and set it.
+    cls = bl.__class__
+    prop_func, prop_def = getattr(cls, bounds_attr)
+    RemoveProperty(cls, attr=bounds_attr)
+    del prop_def["attr"]
+
+    # Remove the things we don't want in a copy to prevent hosing the new property.
+    old_prop_def = dict(prop_def)
+    del old_prop_def["get"]
+    del old_prop_def["set"]
+    setattr(cls, bounds_attr, prop_func(**old_prop_def))
+    bounds_value_new = getattr(bl, bounds_attr)
+
+    # Re-register new property.
+    RemoveProperty(cls, attr=bounds_attr)
+    setattr(cls, bounds_attr, prop_func(**prop_def))
+
+    # Only set the property if the value different to avoid thrashing and log spam.
+    if bounds_value_curr != bounds_value_new:
+        print(f"Stashing bounds property: [{bl.name}] ({cls.__name__}) {bounds_value_curr} -> {bounds_value_new}") # TEMP
+        setattr(bl, bounds_attr, bounds_value_new)

--- a/korman/enum_props.py
+++ b/korman/enum_props.py
@@ -1,0 +1,62 @@
+#    This file is part of Korman.
+#
+#    Korman is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Korman is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from bpy.props import *
+
+from typing import *
+
+# These are the kinds of physical bounds Plasma can work with.
+# This sequence is acceptable in any EnumProperty
+_bounds_types = (
+    ("box", "Bounding Box", "Use a perfect bounding box"),
+    ("sphere", "Bounding Sphere", "Use a perfect bounding sphere"),
+    ("hull", "Convex Hull", "Use a convex set encompasing all vertices"),
+    ("trimesh", "Triangle Mesh", "Use the exact triangle mesh (SLOW!)")
+)
+
+def _bounds_type_index(key: str) -> int:
+    return list(zip(*_bounds_types))[0].index(key)
+
+def _bounds_type_str(idx: int) -> str:
+    return _bounds_types[idx][0]
+
+def _get_bounds(physics_attr: Optional[str]) -> Callable[[Any], int]:
+    def getter(self) -> int:
+        physics_object = getattr(self, physics_attr) if physics_attr is not None else self.id_data
+        if physics_object is not None:
+            return _bounds_type_index(physics_object.plasma_modifiers.collision.bounds)
+        return _bounds_type_index("hull")
+    return getter
+
+def _set_bounds(physics_attr: Optional[str]) -> Callable[[Any, int], None]:
+    def setter(self, value: int):
+        physics_object = getattr(self, physics_attr) if physics_attr is not None else self.id_data
+        if physics_object is not None:
+            physics_object.plasma_modifiers.collision.bounds = _bounds_type_str(value)
+    return setter
+
+def bounds(physics_attr: Optional[str] = None, store_on_collider: bool = True, **kwargs) -> str:
+    assert not {"items", "get", "set"} & kwargs.keys(), "You cannot use the `items`, `get`, or `set` keyword arguments"
+    if store_on_collider:
+        kwargs["get"] = _get_bounds(physics_attr)
+        kwargs["set"] = _set_bounds(physics_attr)
+    if "default" not in kwargs:
+        kwargs["default"] = "hull"
+    return EnumProperty(
+        items=_bounds_types,
+        **kwargs
+    )

--- a/korman/nodes/node_conditions.py
+++ b/korman/nodes/node_conditions.py
@@ -21,8 +21,8 @@ import math
 from PyHSPlasma import *
 from typing import *
 
+from .. import enum_props
 from .node_core import *
-from ..properties.modifiers.physics import bounds_types
 from .. import idprops
 
 class PlasmaClickableNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.Node):
@@ -38,10 +38,13 @@ class PlasmaClickableNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.N
                                        description="Mesh object that is clickable",
                                        type=bpy.types.Object,
                                        poll=idprops.poll_mesh_objects)
-    bounds = EnumProperty(name="Bounds",
-                          description="Clickable's bounds (NOTE: only used if your clickable is not a collider)",
-                          items=bounds_types,
-                          default="hull")
+
+    bounds = enum_props.bounds(
+        "clickable_object", store_on_collider=False,
+        name="Bounds",
+        description="Clickable's bounds (NOTE: only used if your clickable is not a collider)",
+        default="hull"
+    )
 
     input_sockets: dict[str, Any] = {
         "region": {
@@ -162,10 +165,12 @@ class PlasmaClickableRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.t
                                     description="Object that defines the region mesh",
                                     type=bpy.types.Object,
                                     poll=idprops.poll_mesh_objects)
-    bounds = EnumProperty(name="Bounds",
-                          description="Physical object's bounds (NOTE: only used if your clickable is not a collider)",
-                          items=bounds_types,
-                          default="hull")
+    bounds = enum_props.bounds(
+        "region_object", store_on_collider=False,
+        name="Bounds",
+        description="Physical object's bounds (NOTE: only used if your clickable is not a collider)",
+        default="hull"
+    )
 
     output_sockets = {
         "satisfies": {
@@ -419,9 +424,11 @@ class PlasmaVolumeSensorNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.type
                                     description="Object that defines the region mesh",
                                     type=bpy.types.Object,
                                     poll=idprops.poll_mesh_objects)
-    bounds = EnumProperty(name="Bounds",
-                          description="Physical object's bounds",
-                          items=bounds_types)
+    bounds = enum_props.bounds(
+        "region_object", store_on_collider=False,
+        name="Bounds",
+        description="Physical object's bounds"
+    )
 
     # Detector Properties
     report_on = EnumProperty(name="Triggerers",

--- a/korman/nodes/node_conditions.py
+++ b/korman/nodes/node_conditions.py
@@ -23,9 +23,10 @@ from typing import *
 
 from .. import enum_props
 from .node_core import *
+from .node_deprecated import PlasmaVersionedNode
 from .. import idprops
 
-class PlasmaClickableNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.Node):
+class PlasmaClickableNode(idprops.IDPropObjectMixin, PlasmaVersionedNode, bpy.types.Node):
     bl_category = "CONDITIONS"
     bl_idname = "PlasmaClickableNode"
     bl_label = "Clickable"
@@ -40,9 +41,9 @@ class PlasmaClickableNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.N
                                        poll=idprops.poll_mesh_objects)
 
     bounds = enum_props.bounds(
-        "clickable_object", store_on_collider=False,
+        "clickable_object",
         name="Bounds",
-        description="Clickable's bounds (NOTE: only used if your clickable is not a collider)",
+        description="Clickable's bounds",
         default="hull"
     )
 
@@ -154,8 +155,20 @@ class PlasmaClickableNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.N
     def _idprop_mapping(cls):
         return {"clickable_object": "clickable"}
 
+    @property
+    def latest_version(self):
+        return 2
 
-class PlasmaClickableRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.Node):
+    def upgrade(self):
+        # In version 1 of this node, the bounds type was stored on this node. This could
+        # be overridden by whatever was in the collision modifier. Version 2 changes the
+        # bounds property to proxy to the collision modifier's bounds settings.
+        if self.version == 2:
+            enum_props.upgrade_bounds(self, "bounds")
+            self.version = 2
+
+
+class PlasmaClickableRegionNode(idprops.IDPropObjectMixin, PlasmaVersionedNode, bpy.types.Node):
     bl_category = "CONDITIONS"
     bl_idname = "PlasmaClickableRegionNode"
     bl_label = "Clickable Region Settings"
@@ -166,9 +179,9 @@ class PlasmaClickableRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.t
                                     type=bpy.types.Object,
                                     poll=idprops.poll_mesh_objects)
     bounds = enum_props.bounds(
-        "region_object", store_on_collider=False,
+        "region_object",
         name="Bounds",
-        description="Physical object's bounds (NOTE: only used if your clickable is not a collider)",
+        description="Physical object's bounds",
         default="hull"
     )
 
@@ -219,6 +232,18 @@ class PlasmaClickableRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.t
     @classmethod
     def _idprop_mapping(cls):
         return {"region_object": "region"}
+
+    @property
+    def latest_version(self):
+        return 2
+
+    def upgrade(self):
+        # In version 1 of this node, the bounds type was stored on this node. This could
+        # be overridden by whatever was in the collision modifier. Version 2 changes the
+        # bounds property to proxy to the collision modifier's bounds settings.
+        if self.version == 1:
+            enum_props.upgrade_bounds(self, "bounds")
+            self.version = 2
 
 
 class PlasmaClickableRegionSocket(PlasmaNodeSocketBase, bpy.types.NodeSocket):
@@ -400,7 +425,7 @@ class PlasmaVolumeReportNode(PlasmaNodeBase, bpy.types.Node):
             row.prop(self, "threshold", text="")
 
 
-class PlasmaVolumeSensorNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.Node):
+class PlasmaVolumeSensorNode(idprops.IDPropObjectMixin, PlasmaVersionedNode, bpy.types.Node):
     bl_category = "CONDITIONS"
     bl_idname = "PlasmaVolumeSensorNode"
     bl_label = "Region Sensor"
@@ -425,7 +450,7 @@ class PlasmaVolumeSensorNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.type
                                     type=bpy.types.Object,
                                     poll=idprops.poll_mesh_objects)
     bounds = enum_props.bounds(
-        "region_object", store_on_collider=False,
+        "region_object",
         name="Bounds",
         description="Physical object's bounds"
     )
@@ -592,6 +617,18 @@ class PlasmaVolumeSensorNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.type
     def report_exits(self):
         return (self.find_input_socket("exit").allow or
                 self.find_input("exit", "PlasmaVolumeReportNode") is not None)
+
+    @property
+    def latest_version(self):
+        return 2
+
+    def upgrade(self):
+        # In version 1 of this node, the bounds type was stored on this node. This could
+        # be overridden by whatever was in the collision modifier. Version 2 changes the
+        # bounds property to proxy to the collision modifier's bounds settings.
+        if self.version == 1:
+            enum_props.upgrade_bounds(self, "bounds")
+            self.version = 2
 
 
 class PlasmaVolumeSettingsSocket(PlasmaNodeSocketBase):

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -20,8 +20,8 @@ from bpy.props import *
 from typing import *
 from PyHSPlasma import *
 
+from .. import enum_props
 from .node_core import *
-from ..properties.modifiers.physics import bounds_types, bounds_type_index, bounds_type_str
 from .. import idprops
 
 class PlasmaExcludeRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.Node):
@@ -33,25 +33,19 @@ class PlasmaExcludeRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.typ
     # ohey, this can be a Python attribute
     pl_attrib = {"ptAttribExcludeRegion"}
 
-    def _get_bounds(self):
-        if self.region_object is not None:
-            return bounds_type_index(self.region_object.plasma_modifiers.collision.bounds)
-        return bounds_type_index("hull")
-    def _set_bounds(self, value):
-        if self.region_object is not None:
-            self.region_object.plasma_modifiers.collision.bounds = bounds_type_str(value)
-
     region_object = PointerProperty(name="Region",
                                     description="Region object's name",
                                     type=bpy.types.Object,
                                     poll=idprops.poll_mesh_objects)
-    bounds = EnumProperty(name="Bounds",
-                          description="Region bounds",
-                          items=bounds_types,
-                          get=_get_bounds,
-                          set=_set_bounds)
-    block_cameras = BoolProperty(name="Block Cameras",
-                                description="The region blocks cameras when it has been cleared")
+    bounds = enum_props.bounds(
+        "region_object",
+        name="Bounds",
+        description="Region bounds"
+    )
+    block_cameras = BoolProperty(
+        name="Block Cameras",
+        description="The region blocks cameras when it has been cleared"
+    )
 
     input_sockets:dict[str, dict[str, Any]] = {
         "safe_point": {

--- a/korman/properties/modifiers/base.py
+++ b/korman/properties/modifiers/base.py
@@ -263,7 +263,7 @@ def _restore_properties(dummy):
     # again and BOOM--there are no deprecated properties available. Therefore,
     # we reregister them here.
     for mod_cls in PlasmaModifierUpgradable.__subclasses__():
-        for prop_name in mod_cls.deprecated_properties:
+        for prop_name in getattr(mod_cls, "deprecated_properties", []):
             # Unregistered propertes are a sequence of (property function,
             # property keyword arguments). Interesting design decision :)
             prop_cb, prop_kwargs = getattr(mod_cls, prop_name)
@@ -283,6 +283,6 @@ def _upgrade_modifiers(dummy):
     # Now that everything is upgraded, forcibly remove all properties
     # from the modifiers to prevent sneaky zombie-data type export bugs
     for mod_cls in PlasmaModifierUpgradable.__subclasses__():
-        for prop in mod_cls.deprecated_properties:
+        for prop in getattr(mod_cls, "deprecated_properties", []):
             RemoveProperty(mod_cls, attr=prop)
 bpy.app.handlers.load_post.append(_upgrade_modifiers)

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -203,26 +203,6 @@ class GameGuiAnimation(bpy.types.PropertyGroup):
         else:
             return idprops.poll_drawable_objects(self, value)
 
-    def _poll_texture(self, value):
-        # must be a legal option... but is it a member of this material... or, if no material,
-        # any of the materials attached to the object?
-        if self.target_material is not None:
-            return value.name in self.target_material.texture_slots
-        else:
-            target_object = self.target_object if self.target_object is not None else self.id_data
-            for i in (slot.material for slot in target_object.material_slots if slot and slot.material):
-                if value in (slot.texture for slot in i.texture_slots if slot and slot.texture):
-                    return True
-            return False
-
-    def _poll_material(self, value):
-        # Don't filter materials by texture - this would (potentially) result in surprising UX
-        # in that you would have to clear the texture selection before being able to select
-        # certain materials.
-        target_object = self.target_object if self.target_object is not None else self.id_data
-        object_materials = (slot.material for slot in target_object.material_slots if slot and slot.material)
-        return value in object_materials
-
     anim_type: str = EnumProperty(
         name="Type",
         description="Animation type to affect",
@@ -233,23 +213,21 @@ class GameGuiAnimation(bpy.types.PropertyGroup):
         default="OBJECT",
         options=set()
     )
-    target_object: bpy.types.Object = PointerProperty(
+    target_object: bpy.types.Object = idprops.triprop_object(
+        "target_object", "target_material", "target_texure",
         name="Object",
         description="Target object",
         poll=_poll_target_object,
-        type=bpy.types.Object
     )
-    target_material: bpy.types.Material = PointerProperty(
+    target_material: bpy.types.Material = idprops.triprop_material(
+        "target_object", "target_material", "target_texure",
         name="Material",
         description="Target material",
-        type=bpy.types.Material,
-        poll=_poll_material
     )
-    target_texture: bpy.types.Texture = PointerProperty(
+    target_texture: bpy.types.Texture = idprops.triprop_texture(
+        "target_object", "target_material", "target_texure",
         name="Texture",
         description="Target texture",
-        type=bpy.types.Texture,
-        poll=_poll_texture
     )
 
 

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -30,9 +30,9 @@ if TYPE_CHECKING:
 
 from ...addon_prefs import game_versions
 from .base import PlasmaModifierProperties, PlasmaModifierLogicWiz
+from ... import enum_props
 from ...exporter import ExportError, utils
 from ... import idprops
-from .physics import bounds_type_index, bounds_type_str, bounds_types
 
 entry_cam_pfm = {
     "filename": "xEntryCam.py",
@@ -103,15 +103,6 @@ class PlasmaSpawnPoint(PlasmaModifierProperties, PlasmaModifierLogicWiz):
     bl_description = "Point at which avatars link into the Age"
     bl_object_types = {"EMPTY"}
 
-    def _get_bounds(self) -> int:
-        if self.exit_region is not None:
-            return bounds_type_index(self.exit_region.plasma_modifiers.collision.bounds_type)
-        return bounds_type_index("hull")
-
-    def _set_bounds(self, value: int) -> None:
-        if self.exit_region is not None:
-            self.exit_region.plasma_modifiers.collision.bounds_type = bounds_type_str(value)
-
     entry_camera = PointerProperty(
         name="Entry Camera",
         description="Camera to use when the player spawns at this location",
@@ -126,12 +117,10 @@ class PlasmaSpawnPoint(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         poll=idprops.poll_mesh_objects
     )
 
-    bounds_type = EnumProperty(
+    bounds_type = enum_props.bounds(
+        "exit_region",
         name="Bounds",
         description="",
-        items=bounds_types,
-        get=_get_bounds,
-        set=_set_bounds,
         default="hull"
     )
 

--- a/korman/properties/modifiers/physics.py
+++ b/korman/properties/modifiers/physics.py
@@ -18,17 +18,9 @@ from bpy.props import *
 from PyHSPlasma import *
 
 from .base import PlasmaModifierProperties
+from ...enum_props import _bounds_types
 from ...exporter import ExportError
 from ... import idprops
-
-# These are the kinds of physical bounds Plasma can work with.
-# This sequence is acceptable in any EnumProperty
-bounds_types = (
-    ("box", "Bounding Box", "Use a perfect bounding box"),
-    ("sphere", "Bounding Sphere", "Use a perfect bounding sphere"),
-    ("hull", "Convex Hull", "Use a convex set encompasing all vertices"),
-    ("trimesh", "Triangle Mesh", "Use the exact triangle mesh (SLOW!)")
-)
 
 # These are the collision sound surface types
 surface_types = (
@@ -55,12 +47,6 @@ subworld_types = (
     ("subworld", "Separate World", "Causes all objects to be placed in a separate physics simulation"),
 )
 
-def bounds_type_index(key):
-    return list(zip(*bounds_types))[0].index(key)
-
-def bounds_type_str(idx):
-    return bounds_types[idx][0]
-
 def _set_phys_prop(prop, sim, phys, value=True):
     """Sets properties on plGenericPhysical and plSimulationInterface (seeing as how they are duped)"""
     sim.setProperty(prop, value)
@@ -78,7 +64,7 @@ class PlasmaCollider(PlasmaModifierProperties):
 
     bounds = EnumProperty(name="Bounds Type",
                           description="",
-                          items=bounds_types,
+                          items=_bounds_types,
                           default="hull")
 
     avatar_blocker = BoolProperty(name="Blocks Avatars",

--- a/korman/properties/modifiers/region.py
+++ b/korman/properties/modifiers/region.py
@@ -22,7 +22,7 @@ from ...exporter import ExportError, ExportAssertionError
 from ...helpers import bmesh_from_object
 from ... import idprops
 
-from .base import PlasmaModifierProperties, PlasmaModifierLogicWiz
+from .base import PlasmaModifierProperties, PlasmaModifierUpgradable, PlasmaModifierLogicWiz
 from ... import enum_props
 from ..prop_camera import PlasmaCameraProperties
 
@@ -128,7 +128,7 @@ class PlasmaCameraRegion(PlasmaModifierProperties):
         return self.camera_type == "auto_follow"
 
 
-class PlasmaFootstepRegion(PlasmaModifierProperties, PlasmaModifierLogicWiz):
+class PlasmaFootstepRegion(PlasmaModifierProperties, PlasmaModifierUpgradable, PlasmaModifierLogicWiz):
     pl_id = "footstep"
 
     bl_category = "Region"
@@ -143,7 +143,6 @@ class PlasmaFootstepRegion(PlasmaModifierProperties, PlasmaModifierLogicWiz):
         default="stone"
     )
     bounds = enum_props.bounds(
-        store_on_collider=False,
         name="Region Bounds",
         description="Physical object's bounds",
         default="hull"
@@ -175,6 +174,16 @@ class PlasmaFootstepRegion(PlasmaModifierProperties, PlasmaModifierLogicWiz):
     @property
     def key_name(self):
         return "{}_FootRgn".format(self.id_data.name)
+
+    @property
+    def latest_version(self):
+        return 2
+
+    def upgrade(self):
+        # Version 2 converts the bounds type to a proxy to the collision modifier.
+        if self.current_version < 2:
+            enum_props.upgrade_bounds(self, "bounds")
+            self.current_version = 2
 
 
 class PlasmaPanicLinkRegion(PlasmaModifierProperties):

--- a/korman/properties/modifiers/region.py
+++ b/korman/properties/modifiers/region.py
@@ -23,8 +23,8 @@ from ...helpers import bmesh_from_object
 from ... import idprops
 
 from .base import PlasmaModifierProperties, PlasmaModifierLogicWiz
+from ... import enum_props
 from ..prop_camera import PlasmaCameraProperties
-from .physics import bounds_types
 
 footstep_surface_ids = {
     "dirt": 0,
@@ -136,14 +136,18 @@ class PlasmaFootstepRegion(PlasmaModifierProperties, PlasmaModifierLogicWiz):
     bl_description = "Footstep Region"
     bl_object_types = {"MESH"}
 
-    surface = EnumProperty(name="Surface",
-                           description="What kind of surface are we walking on?",
-                           items=footstep_surfaces,
-                           default="stone")
-    bounds = EnumProperty(name="Region Bounds",
-                          description="Physical object's bounds",
-                          items=bounds_types,
-                          default="hull")
+    surface = EnumProperty(
+        name="Surface",
+        description="What kind of surface are we walking on?",
+        items=footstep_surfaces,
+        default="stone"
+    )
+    bounds = enum_props.bounds(
+        store_on_collider=False,
+        name="Region Bounds",
+        description="Physical object's bounds",
+        default="hull"
+    )
 
     def logicwiz(self, bo, tree):
         nodes = tree.nodes


### PR DESCRIPTION
This is a set of changes to de-duplicate code and storage of bounds and animation related properties. All bounds properties are now proxies to the collision modifier's bounds property with an automated upgrade path. All of the manual getters and setters in code that was already doing this have been removed and replaced with a helper to register bounds properties. Animation properties, especially material/texture animations, have been greatly simplified by removing verbose boilerplate around property registration.