### PR TITLE
GUIDialog Python Proc fixes

### DIFF
--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -36,7 +36,7 @@ _pool_types = (
     plFactory.ClassIndex("plDynaRippleMgr"),
     plFactory.ClassIndex("plDynaBulletMgr"),
     plFactory.ClassIndex("plDynaPuddleMgr"),
-    plFactory.ClassIndex("plATCAnim"),
+    #plFactory.ClassIndex("plATCAnim"), # Only Avatar Animations need to be pool objects
     plFactory.ClassIndex("plEmoteAnim"),
     plFactory.ClassIndex("plDynaRippleVSMgr"),
     plFactory.ClassIndex("plDynaTorpedoMgr"),

--- a/korman/exporter/manager.py
+++ b/korman/exporter/manager.py
@@ -256,7 +256,7 @@ class ExportManager:
         key = self._keys.get((location, pClass, name), None)
         if key is not None and so is not None:
             # Purposefully not checking for plObjInterface -- they should never be shared.
-            if issubclass(pClass, plModifier):
+            if issubclass(pClass, plModifier) and plFactory.ClassIndex(pClass.__name__) not in _pool_types:
                 if key not in so.modifiers:
                     # We really shouldn't add plSingleModifiers to multiple objects. This may
                     # potentially cause URU to crash. I'm uncertain though, so we'll just warn

--- a/korman/nodes/node_python.py
+++ b/korman/nodes/node_python.py
@@ -751,10 +751,10 @@ class PlasmaAttribObjectNode(idprops.IDPropObjectMixin, PlasmaAttribNodeBase, bp
         layout.prop(self, "target_object", text=self.attribute_name)
 
     def get_key(self, exporter, so):
-        attrib = self.to_socket
-        if attrib is None:
+        attrib_socket = self.to_socket
+        if attrib_socket is None:
             self.raise_error("must be connected to a Python File node!")
-        attrib = attrib.attribute_type
+        attrib = attrib_socket.attribute_type
 
         bo = self.target_object
         if bo is None:
@@ -788,7 +788,7 @@ class PlasmaAttribObjectNode(idprops.IDPropObjectMixin, PlasmaAttribNodeBase, bp
             if not gui_dialog.enabled:
                 self.raise_error(f"GUI Dialog modifier not enabled on '{self.object_name}'")
             dialog_mod = exporter.mgr.find_create_object(pfGUIDialogMod, so=ref_so, bl=bo)
-            dialog_mod.procReceiver = attrib.node.get_key(exporter, so)
+            dialog_mod.procReceiver = attrib_socket.node.get_key(exporter, so)
             return dialog_mod.key
 
     @classmethod

--- a/korman/properties/modifiers/logic.py
+++ b/korman/properties/modifiers/logic.py
@@ -57,6 +57,7 @@ class PlasmaVersionedNodeTree(idprops.IDPropMixin, bpy.types.PropertyGroup):
 
 class PlasmaAdvancedLogic(PlasmaModifierProperties):
     pl_id = "advanced_logic"
+    pl_page_types = {"gui", "room"}
 
     bl_category = "Logic"
     bl_label = "Advanced"


### PR DESCRIPTION
* Fixes an error when a PythonFileMod tries to set itself as the proc for a GUIDialog (which happens when a dialog is passed in as a Python attribute)
* Fixes a case where GUIDialogs would get added as pool objects to the scene node, but also (incorrectly) get attached as modifiers to a SceneObject. This can cause Uru to crash because things load in the wrong order (which is its own problem that I'm not spending more time debugging tonight)
* Allow creating node trees in GUI pages. Sometimes you want a PythonFileMod in a GUI page, or sometimes you want a ResponderModifier in a GUI page.
* Fix a case where all ATC anims were being listed as pool objects which is not necessary except in the case of avatar animations (and those should in future probably be special cased like GUI pages are)