### PR TITLE
Add Color Picker to DynText Modifier

### DIFF
--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -123,6 +123,7 @@ def dynatext(modifier, layout, context):
     sub.alert = not modifier.font_face.strip()
     sub.prop(modifier, "font_face", text="", icon="OUTLINER_DATA_FONT")
     col.prop(modifier, "font_size", text="Size")
+    col.prop(modifier, "font_color", text="")
 
     layout.separator()
     split = layout.split()


### PR DESCRIPTION
Small addition to the Localized/DynText modifier to add a color picker for the font color in the font options. Utilizes the existing `font_color` def in properties.