### PR TITLE
Add GUI Page type to pl_page_types for Modifiers

### DIFF
--- a/korman/properties/modifiers/base.py
+++ b/korman/properties/modifiers/base.py
@@ -32,7 +32,7 @@ class PlasmaModifierProperties(bpy.types.PropertyGroup):
     @property
     def allowed(self) -> bool:
         """Returns if this modifier is allowed to be enabled on the owning Object"""
-        allowed_page_types = getattr(self, "pl_page_types", {"room"})
+        allowed_page_types = getattr(self, "pl_page_types", {"room", "gui"})
         allowed_object_types = getattr(self, "bl_object_types", set())
         page_name = self.id_data.plasma_object.page
         if not allowed_object_types or self.id_data.type in allowed_object_types:


### PR DESCRIPTION
I noticed this while working on getting face/swivel mods working for Empty objects (another issue). The modifier properties use `room` and `gui` in `pl_page_types` to determine which modifier can work in which type of page. I found this wasn't working completely due to a missing reference in the `base.py` script. This fix adds the reference and gets the missing modifiers working for GUIs, such as the Advanced mod for Python scripts.