### PR TITLE
Allow FaceMod/Swivel on Empty Objects

### DIFF
--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -798,7 +798,7 @@ class PlasmaViewFaceMod(idprops.IDPropObjectMixin, PlasmaModifierProperties):
     bl_category = "Render"
     bl_label = "Swivel"
     bl_description = "Swivel object to face the camera, player, or another object"
-    bl_object_types = {"MESH", "FONT"}
+    bl_object_types = {"MESH", "FONT", "EMPTY"}
 
     preset_options = EnumProperty(name="Type",
                                   description="Type of Facing",


### PR DESCRIPTION
Certain animated objects, such as the flames for the Menorah in the city and the New Messengers Pub, need an empty that can swivel for both functions to work properly. If an animated object has both scale animation and swivel, it doesn't animate, for example. I noticed this while converting the city.

This PR will allow EMPTY objects to have swivel/FaceMod. See city/Ae'gura files and menorah dummy objects for examples of this.