### PR TITLE
Fix External Page Export

### DIFF
--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -213,7 +213,7 @@ class Exporter:
 
                 if (default_enabled and not page) or (page in pages_enabled):
                     self._objects.append(obj)
-                elif page not in all_pages or page in external_pages:
+                elif page not in all_pages or page not in external_pages:
                     error.add(page, obj.name)
             inc_progress()
         error.raise_if_error()


### PR DESCRIPTION
Small fix to stop pages set to External from triggering the "invalid page" error.