### PR TITLE
Fix anim message not picking up objects

### DIFF
--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -117,7 +117,7 @@ class PlasmaAnimCmdMsgNode(idprops.IDPropMixin, PlasmaMessageWithCallbacksNode, 
     def _poll_target_object(self, value: bpy.types.Object) -> bool:
         if self.anim_type == "TEXTURE":
             return idprops.poll_drawable_objects(self, value)
-        elif self.anim_type == "MESH":
+        elif self.anim_type == "OBJECT":
             return idprops.poll_animated_objects(self, value)
         else:
             raise RuntimeError()


### PR DESCRIPTION
Anim message node didn't pick up objects and spammed the console with errors. This fixes that.
(It does still allow selecting objects without a Korman animation modifier though, I don't know if it's intentional.)