### PR TITLE
Add mitigations for #423.

### DIFF
--- a/korman/exporter/camera.py
+++ b/korman/exporter/camera.py
@@ -97,6 +97,10 @@ class CameraConverter:
                 continue
             cam_trans = plCameraModifier.CamTrans()
             if manual_trans.camera:
+                # Don't even bother if a disabled camera is referenced. If we export camera modifier
+                # for a disabled camera, then it won't get a brain, and the client will crash.
+                if not manual_trans.camera.plasma_object.enabled:
+                    continue
                 cam_trans.transTo = self._mgr.find_create_key(plCameraModifier, bl=manual_trans.camera)
             cam_trans.ignore = manual_trans.mode == "ignore"
 

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -770,6 +770,8 @@ class MaterialConverter:
             # least a SceneObject and CoordInterface so that we can touch it...
             # NOTE: that harvest_actor makes sure everyone alread knows we're going to have a CI
             if isinstance(viewpt.data, bpy.types.Camera):
+                if not viewpt.plasma_object.enabled:
+                    raise ExportError(f"DynamicCamMap '{texture.name} wants to use the camera '{viewpt.name}', but it is not a Plasma Object!")
                 pl_env.camera = self._mgr.find_create_key(plCameraModifier, bl=viewpt)
             else:
                 pl_env.rootNode = self._mgr.find_create_key(plSceneObject, bl=viewpt)


### PR DESCRIPTION
Fixes #423.

All `plCameraModifier` objects *must* have a brain or the client will crash dereferencing a null pointer. This commit audits all `plCameraModifier` creations and ensures that we are using a camera that will have a brain. There are probably better ways to do this, but I am le tired.

CC @DoobesURU 