### PR TITLE
Correctly export vertex normals

### DIFF
--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -394,9 +394,11 @@ class MeshConverter(_MeshManager):
                 continue
 
             face_verts = []
-            use_smooth = tessface.use_smooth
             dPosDu = hsVector3(0.0, 0.0, 0.0)
             dPosDv = hsVector3(0.0, 0.0, 0.0)
+
+            # Unpack normals
+            tessface_normals = [tuple(n) for n in tessface.split_normals]
 
             # Unpack the UV coordinates from each UV Texture layer
             # NOTE: Blender has no third (W) coordinate
@@ -446,6 +448,7 @@ class MeshConverter(_MeshManager):
 
             # Convert to per-material indices
             for j, vertex in enumerate(tessface.vertices):
+                vertex_normal = tessface_normals[j]
                 uvws = tuple([tuple(uvw[j]) for uvw in tessface_uvws])
 
                 # Calculate vertex colors.
@@ -462,18 +465,14 @@ class MeshConverter(_MeshManager):
                 # Now, we'll index into the vertex dict using the per-face elements :(
                 # We're using tuples because lists are not hashable. The many mathutils and PyHSPlasma
                 # types are not either, and it's entirely too much work to fool with all that.
-                coluv = (vertex_color, uvws)
-                if coluv not in data.blender2gs[vertex]:
+                normcoluv = (vertex_normal, vertex_color, uvws)
+                if normcoluv not in data.blender2gs[vertex]:
                     source = mesh.vertices[vertex]
                     geoVertex = plGeometrySpan.TempVertex()
                     geoVertex.position = hsVector3(*source.co)
 
-                    # If this face has smoothing, use the vertex normal
-                    # Otherwise, use the face normal
-                    normal = source.normal if use_smooth else tessface.normal
-
                     # MOUL/DX9 craps its pants if any element of the normal is exactly 0.0
-                    normal = map(lambda x: max(x, 0.01) if x >= 0.0 else min(x, -0.01), normal)
+                    normal = map(lambda x: max(x, 0.01) if x >= 0.0 else min(x, -0.01), vertex_normal)
                     normal = hsVector3(*normal)
                     normal.normalize()
                     geoVertex.normal = normal
@@ -486,7 +485,7 @@ class MeshConverter(_MeshManager):
                     geoVertex.uvs = uvs
 
                     idx = len(data.vertices)
-                    data.blender2gs[vertex][coluv] = idx
+                    data.blender2gs[vertex][normcoluv] = idx
                     data.vertices.append(geoVertex)
                     face_verts.append(idx)
                 else:
@@ -494,7 +493,7 @@ class MeshConverter(_MeshManager):
                     # this face to the vertex's magic channels
                     if bumpmap is not None:
                         num_user_uvs = len(uvws)
-                        geoVertex = data.vertices[data.blender2gs[vertex][coluv]]
+                        geoVertex = data.vertices[data.blender2gs[vertex][normcoluv]]
 
                         # Unfortunately, PyHSPlasma returns a copy of everything. Previously, editing
                         # in place would result in silent failures; however, as of python_refactor,
@@ -503,7 +502,7 @@ class MeshConverter(_MeshManager):
                         geoUVs[num_user_uvs] += dPosDu
                         geoUVs[num_user_uvs+1] += dPosDv
                         geoVertex.uvs = geoUVs
-                    face_verts.append(data.blender2gs[vertex][coluv])
+                    face_verts.append(data.blender2gs[vertex][normcoluv])
 
             # Convert to triangles, if need be...
             num_faces = len(face_verts)
@@ -614,6 +613,7 @@ class MeshConverter(_MeshManager):
                 return self._export_mesh(bo, mesh)
 
     def _export_mesh(self, bo, mesh):
+        mesh.calc_normals_split()
         mesh.calc_tessface()
 
         # Step 0.8: Determine materials needed for export... Three considerations here:

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -398,7 +398,7 @@ class MeshConverter(_MeshManager):
             dPosDv = hsVector3(0.0, 0.0, 0.0)
 
             # Unpack normals
-            tessface_normals = [tuple(n) for n in tessface.split_normals]
+            tessface_normals = tessface.split_normals
 
             # Unpack the UV coordinates from each UV Texture layer
             # NOTE: Blender has no third (W) coordinate
@@ -448,7 +448,7 @@ class MeshConverter(_MeshManager):
 
             # Convert to per-material indices
             for j, vertex in enumerate(tessface.vertices):
-                vertex_normal = tessface_normals[j]
+                vertex_normal = tuple(tessface_normals[j])
                 uvws = tuple([tuple(uvw[j]) for uvw in tessface_uvws])
 
                 # Calculate vertex colors.


### PR DESCRIPTION
As it is now, Korman does not correctly export vertex normals as they appear in Blender.

Blender computes actual mesh normals (=what is used by the viewport for shading) according to (non exhaustive list):
- shared vertices between polygons
- polygon smoothness (`use_smooth`)
- edge sharpness (`use_edge_sharp`)
- mesh auto smooth+angle (mesh `use_auto_smooth` & `auto_smooth_angle`). Very useful for modelling machines with both smooth and sharp angles !
- potential custom split normals data (not sure how it works to be honest)

On export, Korman currently tries to reuse common vertices between polygons (which is good), but is a bit too eager and reuses vertices which are part of polygons with different normals. It also doesn't use the right property to get the actual normal that respects all of the above (edge sharpness, auto smooth angle, etc). There are some times where it kinda works and others where it fails, but I won't get into the details.

What this MR does is retrieve the true normal (again, what is used by Blender's viewport, more or less) and use that when looking for an existing vertex / exporting a new vertex.

Pros:
- Lighting effects that involve vertex normals now behave closer to the Blender counterparts. Off the top of my head, this means runtime lighting, specular highlights, and reflection cubemaps. Very important IMHO, I'm a sucker for properly split normals.

Cons:
- Slightly heavier DrawableSpan due to more vertices being generated.
- May hit the vertex number limit earlier, even for people who don't want or need normal-based effects.

Backwards compatibility: previous files will see improvements if re-exported, if they relied on any of the previously mentioned effects (RT light, specular, cubemaps). No effect on baked lighting. May cause big meshes that previously exported fine to hit the vertex limit and fail.

Example of properly exported normals:
![MR_normals_image](https://github.com/user-attachments/assets/f8ad2039-be7e-4248-9934-52ef7a8d6ddf)
Left: Plasma result of a cubemapped object. Middle: mesh normals, seen using Blender's matcap. Right: edit mode displaying sharp edges.
