### PR TITLE
Armatures and skinned objects

### DIFF
--- a/korman/exporter/armature.py
+++ b/korman/exporter/armature.py
@@ -1,0 +1,92 @@
+#    This file is part of Korman.
+#
+#    Korman is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Korman is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Korman.  If not, see <http://www.gnu.org/licenses/>.
+
+import bpy
+from mathutils import Matrix
+import weakref
+from PyHSPlasma import *
+
+from . import utils
+
+class ArmatureConverter:
+    def __init__(self, exporter):
+        self._exporter = weakref.ref(exporter)
+
+    def convert_armature_to_empties(self, bo):
+        # Creates Blender equivalents to each bone of the armature, adjusting a whole bunch of stuff along the way.
+        # Yes, this is ugly, but required to get anims to export properly. I tried other ways to export armatures,
+        # but AFAICT sooner or later you have to implement similar hacks. Might as well create something that the
+        # animation exporter can already deal with, with no modification...
+        # Don't worry, we'll return a list of temporary objects to clean up after ourselves.
+        armature = bo.data
+        pose = bo.pose if armature.pose_position == "POSE" else None
+        generated_bones = {} # name: Blender empty.
+        temporary_objects = []
+        for bone in armature.bones:
+            if bone.parent:
+                continue
+            self._export_bone(bo, bone, bo, Matrix.Identity(4), pose, generated_bones, temporary_objects)
+
+        if bo.plasma_modifiers.animation.enabled and bo.animation_data is not None and bo.animation_data.action is not None:
+            # Let the anim exporter handle the anim crap.
+            temporary_objects.extend(self._exporter().animation.copy_armature_animation_to_temporary_bones(bo, generated_bones))
+
+        return temporary_objects
+
+    def _export_bone(self, bo, bone, parent, matrix, pose, generated_bones, temporary_objects):
+        bone_empty = bpy.data.objects.new(ArmatureConverter.get_bone_name(bo, bone), None)
+        bpy.context.scene.objects.link(bone_empty)
+        bone_empty.plasma_object.enabled = True
+
+        # Grmbl, animation is relative to rest pose in Blender, and relative to parent in Plasma...
+        # Using matrix_parent_inverse or manually adjust keyframes will just mess up rotation keyframes,
+        # so let's just insert an extra empty object to correct all that. This is why the CoordinateInterface caches computed matrices, after all...
+        bone_parent = bpy.data.objects.new(bone_empty.name + "_REST", None)
+        bpy.context.scene.objects.link(bone_parent)
+        bone_parent.plasma_object.enabled = True
+        bone_parent.parent = parent
+        bone_empty.parent = bone_parent
+        bone_empty.matrix_local = Matrix.Identity(4)
+
+        if pose is not None:
+            pose_bone = pose.bones[bone.name]
+            bone_empty.rotation_mode = pose_bone.rotation_mode
+            pose_matrix = pose_bone.matrix_basis
+        else:
+            pose_bone = None
+            pose_matrix = Matrix.Identity(4)
+
+        temporary_objects.append(bone_empty)
+        temporary_objects.append(bone_parent)
+        generated_bones[bone.name] = bone_empty
+        bone_parent.matrix_local = matrix * bone.matrix_local.to_4x4() * pose_matrix
+
+        for child in bone.children:
+            child_empty = self._export_bone(bo, child, bone_empty, bone.matrix_local.inverted(), pose, generated_bones, temporary_objects)
+        return bone_empty
+
+    @staticmethod
+    def get_bone_name(bo, bone):
+        if isinstance(bone, str):
+            return "{}_{}".format(bo.name, bone)
+        return "{}_{}".format(bo.name, bone.name)
+
+    @property
+    def _mgr(self):
+        return self._exporter().mgr
+
+    @property
+    def _report(self):
+        return self._exporter().report

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -560,9 +560,7 @@ class Exporter:
                 so = self.mgr.find_create_object(plSceneObject, bl=bo)
                 self._export_actor(so, bo)
                 # Bake all armature bones to empties - this will make it easier to export animations and such.
-                for temporary_object in self.armature.convert_armature_to_empties(bo):
-                    # This could be a Blender object, an action, a context manager... I have no idea, handle_temporary will figure it out !
-                    handle_temporary(temporary_object, bo)
+                self.armature.convert_armature_to_empties(bo, lambda obj: handle_temporary(obj, bo))
             for mod in bo.plasma_modifiers.modifiers:
                 proc = getattr(mod, "pre_export", None)
                 if proc is not None:

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -215,14 +215,8 @@ class _MeshManager:
                         mod_prop_dict = self._build_prop_dict(mod)
                         cache_mods.append(mod_prop_dict)
 
-                    armatures = []
-                    for armature_mod in self._exporter().armature.get_skin_modifiers(i):
-                        # We'll use armatures to export bones later. Disable it so it doesn't get baked into the mesh.
-                        armatures.append(armature_mod.object)
-                        # Note that this gets reverted when we reapply cached modifiers.
-                        armature_mod.show_render = False
-                    if armatures:
-                        self._objects_armatures[i.name] = armatures
+                    # Disable armatures if need be (only when exporting)
+                    self._disable_armatures(i)
 
                 i.data = i.to_mesh(scene, True, "RENDER", calc_tessface=False)
 
@@ -253,6 +247,10 @@ class _MeshManager:
                             continue
                         setattr(mod, key, value)
             self._entered = False
+
+    def _disable_armatures(self, bo):
+        # Overridden when necessary.
+        pass
 
     def is_collapsed(self, bo) -> bool:
         return bo.name in self._overrides
@@ -370,6 +368,16 @@ class MeshConverter(_MeshManager):
             geospan.addPermaProj(i)
 
         return geospan
+
+    def _disable_armatures(self, bo):
+        armatures = []
+        for armature_mod in self._exporter().armature.get_skin_modifiers(bo):
+            # We'll use armatures to export bones later. Disable it so it doesn't get baked into the mesh.
+            armatures.append(armature_mod.object)
+            # Note that this gets reverted when we reapply cached modifiers.
+            armature_mod.show_render = False
+        if armatures:
+            self._objects_armatures[bo.name] = armatures
 
     def finalize(self):
         """Prepares all baked Plasma geometry to be flushed to the disk"""

--- a/korman/exporter/mesh.py
+++ b/korman/exporter/mesh.py
@@ -21,6 +21,7 @@ from math import fabs
 from typing import Iterable
 import weakref
 
+from .armature import ArmatureConverter
 from ..exporter.logger import ExportProgressLogger
 from . import explosions
 from .. import helpers
@@ -157,6 +158,8 @@ class _GeoData:
         self.blender2gs = [{} for i in range(numVtxs)]
         self.triangles = []
         self.vertices = []
+        self.max_deform_bones = 0
+        self.total_weight_by_bones = {}
 
 
 class _MeshManager:
@@ -166,6 +169,8 @@ class _MeshManager:
             self._report = report
         self._entered = False
         self._overrides = {}
+        self._objects_armatures = {}
+        self._geospans_armatures = {}
 
     @staticmethod
     def add_progress_presteps(report):
@@ -200,15 +205,30 @@ class _MeshManager:
                 # Remember, storing actual pointers to the Blender objects can cause bad things to
                 # happen because Blender's memory management SUCKS!
                 self._overrides[i.name] = { "mesh": i.data.name, "modifiers": [] }
-                i.data = i.to_mesh(scene, True, "RENDER", calc_tessface=False)
 
                 # If the modifiers are left on the object, the lightmap bake can break under some
-                # situations. Therefore, we now cache the modifiers and clear them away...
+                # situations. Therefore, we now cache the modifiers and will clear them away...
                 if i.plasma_object.enabled:
                     cache_mods = self._overrides[i.name]["modifiers"]
+
                     for mod in i.modifiers:
-                        cache_mods.append(self._build_prop_dict(mod))
+                        mod_prop_dict = self._build_prop_dict(mod)
+                        cache_mods.append(mod_prop_dict)
+
+                    armatures = []
+                    for armature_mod in self._exporter().armature.get_skin_modifiers(i):
+                        # We'll use armatures to export bones later. Disable it so it doesn't get baked into the mesh.
+                        armatures.append(armature_mod.object)
+                        # Note that this gets reverted when we reapply cached modifiers.
+                        armature_mod.show_render = False
+                    if armatures:
+                        self._objects_armatures[i.name] = armatures
+
+                i.data = i.to_mesh(scene, True, "RENDER", calc_tessface=False)
+
+                if i.plasma_object.enabled:
                     i.modifiers.clear()
+
             self._report.progress_increment()
         return self
 
@@ -365,6 +385,9 @@ class MeshConverter(_MeshManager):
                 for dspan in loc.values():
                     log_msg("[DrawableSpans '{}']", dspan.key.name)
 
+                    # We do one last pass to register bones.
+                    self._register_bones_before_merge(dspan)
+
                     # This mega-function does a lot:
                     # 1. Converts SourceSpans (geospans) to Icicles and bakes geometry into plGBuffers
                     # 2. Calculates the Icicle bounds
@@ -372,6 +395,87 @@ class MeshConverter(_MeshManager):
                     # 4. Clears the SourceSpans
                     dspan.composeGeometry(True, True)
                 inc_progress()
+
+    def _register_bones_before_merge(self, dspan):
+        # We export all armatures used by this DSpan only once, unless an object uses multiple armatures - in which case, we treat the list of armatures as a single armature:
+        # [Armature 0: bone A, bone B, bone C...]
+        # [Armature 1: bone D, bone E, bone F...]
+        # [Armature 0, armature 1: bone A, bone B, bone C... bone D, bone E, bone F...]
+        # But really, the latter case should NEVER happen because users never use more than one armature modifier, cm'on.
+        # NOTE: we will export all bones, even those that are not used by any vertices in the DSpan. Would be too complex otherwise.
+        # NOTE: DSpan bone transforms are shared between all drawables in this dspan. This implies all skinned meshes must share the same
+        # coordinate system - and that's easier if these objects simply don't have a coordinate interface.
+        # Hence, we forbid skinned objects from having a coordint.
+        # The alternative is exporting each bone once per drawable with different l2w/w2l/l2b/b2l, but this is more complex
+        # and there is no good reason to do so - this just increases the risk of deformations going crazy due to a misaligned object.
+
+        armature_list_to_base_matrix = {}
+
+        def find_create_armature(armature_list):
+            nonlocal armature_list_to_base_matrix
+            existing_base_matrix = armature_list_to_base_matrix.get(armature_list)
+            if existing_base_matrix is not None:
+                # Armature already exported. Return the base bone ID.
+                return existing_base_matrix
+
+            # Not already exported. Do so now.
+            # Will be used to offset the DI/icicle's baseMatrix.
+            base_matrix_id = dspan.numTransforms
+            armature_list_to_base_matrix[armature_list] = base_matrix_id
+            for armature in armature_list:
+                # Create the null bone. We have 1 per matrix
+                identity = hsMatrix44.Identity()
+                dspan.addTransform(identity, identity, identity, identity)
+                # Now create the transforms for all bones, and make sure they are referenced by a draw interface.
+                for bone in armature.data.bones:
+                    find_create_bone(armature, bone)
+
+            return base_matrix_id
+
+        def find_create_bone(armature_bo, bone_bo):
+            bone_so_name = ArmatureConverter.get_bone_name(armature_bo, bone_bo)
+            bone_empty_bo = bpy.context.scene.objects[bone_so_name]
+            bone_empty_so = self._mgr.find_object(plSceneObject, bl=bone_empty_bo)
+
+            # Add the bone's transform.
+            identity = hsMatrix44.Identity()
+            localToWorld = utils.matrix44(self._exporter().armature.get_bone_local_to_world(bone_empty_bo))
+            transform_index = dspan.addTransform( \
+                # local2world, world2local: always identity it seems.
+                identity, identity, \
+                # local2bone, bone2local
+                localToWorld.inverse(), localToWorld)
+
+            # Add a draw interface to the object itself (if not already done).
+            di = self._mgr.find_create_object(plDrawInterface, bl=bone_empty_bo, so=bone_empty_so)
+            bone_empty_so.draw = di.key
+
+            # If the DI already has a reference to the DSpan, add the transform to the dspan's DIIndex.
+            # If not, create the DIIndex and the transform, and add it to the DI.
+            found = False
+            for key, id in di.drawables:
+                if dspan.key == key:
+                    # Already exported because the user has an object with two armatures.
+                    # Just readd the transform...
+                    dii = dspan.DIIndices[id]
+                    dii.indices = (*dii.indices, transform_index)
+            if not found:
+                dii = plDISpanIndex()
+                dii.flags = plDISpanIndex.kMatrixOnly
+                dii.indices = (transform_index,)
+                di_index = dspan.addDIIndex(dii)
+                di.addDrawable(dspan.key, di_index)
+
+        for i in range(len(dspan.sourceSpans)):
+            geospan = dspan.sourceSpans[i]
+            # Let's get any armature data.
+            armature_info = self._geospans_armatures.get((dspan, i))
+            if armature_info is None:
+                continue
+            armatures = armature_info[0]
+            # Export the armature (if not already done), and retrieve the BaseMatrix.
+            geospan.baseMatrix = find_create_armature(tuple(armatures))
+            geospan.numMatrices = sum(len(arm.data.bones) for arm in armatures) + 1
 
     def _export_geometry(self, bo, mesh, materials, geospans, mat2span_LUT):
         self._report.msg(f"Converting geometry from '{mesh.name}'...")
@@ -386,6 +490,26 @@ class MeshConverter(_MeshManager):
         lm = bo.plasma_modifiers.lightmap
         color = self._find_vtx_color_layer(mesh.tessface_vertex_colors, autocolor=not lm.bake_lightmap, manual=True)
         alpha = self._find_vtx_alpha_layer(mesh.tessface_vertex_colors)
+
+        # And retrieve the vertex groups that are deformed by an armature.
+        armatures = self._objects_armatures.get(bo.name)
+        export_deform = armatures is not None
+        if export_deform:
+            # We will need to remap IDs of each bone per armature usage. This is annoying, especially since we support multiple armatures...
+            i = 1
+            all_bone_names = {}
+            for armature in armatures:
+                for bone in armature.data.bones:
+                    all_bone_names[bone.name] = i
+                    i += 1
+            # This will map the group ID (used by Blender vertices) to the bone index exported to Plasma.
+            # Theoretically supports multiple armatures, except if the two armatures have the same bone names (because that would be REALLY asking for a lot here).
+            # If the bone is not found, we'll just map to the null bone.
+            group_id_to_bone_id = [all_bone_names.get(group.name, 0) for group in bo.vertex_groups]
+            # We will also need to know which bones deform the most vertices per material, for max/pen bones.
+            for gd in geodata.values():
+                gd.total_weight_by_bones = { j: 0.0 for j in range(i) }
+            warned_extra_bone_weights = False
 
         # Convert Blender faces into things we can stuff into libHSPlasma
         for i, tessface in enumerate(mesh.tessfaces):
@@ -484,6 +608,37 @@ class MeshConverter(_MeshManager):
                         uvs.append(dPosDv)
                     geoVertex.uvs = uvs
 
+                    if export_deform:
+                        # Get bone ID and weight from the vertex' "group" data.
+                        # While we're at it, sort it by weight, and filter groups that
+                        # have no bone assigned. Take only the first 3 bones.
+                        weights = sorted([ \
+                                (group_id_to_bone_id[group.group], group.weight) \
+                                for group in source.groups \
+                                if group.weight > 0 \
+                            ], key=lambda t: t[1], reverse=True)
+                        if len(weights) > 3 and not warned_extra_bone_weights:
+                            warned_extra_bone_weights = True
+                            self._report.warn(f"'{bo.name}': only three bones can deform a vertex at a time. Please use Weight Tools -> Limit Total at 3 to ensure deformation is consistent between Blender and Plasma.")
+                        weights = weights[:3]
+                        total_weight = sum((w[1] for w in weights))
+                        # NOTE: Blender will ALWAYS normalize bone weights when deforming !
+                        # This means if weights don't add up to 1, we CANNOT assign the remaining weight to the null bone.
+                        # For instance, a vertex with a single bone of weight 0.25 will move as if it were weighted 1.0.
+                        # However, a vertex with no bone at all will not move at all (null bone).
+                        weights = [(id, weight / total_weight) for id, weight in weights]
+                        # Count how many bones deform this vertex, so we know how many skin indices to enable.
+                        num_bones = len(weights)
+                        data.max_deform_bones = max(data.max_deform_bones, num_bones)
+                        # Keep track of how much weight each bone is handling
+                        for id, weight in weights:
+                            data.total_weight_by_bones[id] += weight
+                        # Pad to 3 weights to make it simpler.
+                        weights += [(0, 0.0)] * (3 - len(weights))
+                        # And store all this into the vertex.
+                        geoVertex.indices = weights[0][0] | (weights[1][0] << 8) | (weights[2][0] << 16)
+                        geoVertex.weights = tuple((weight for id, weight in weights))
+
                     idx = len(data.vertices)
                     data.blender2gs[vertex][normcoluv] = idx
                     data.vertices.append(geoVertex)
@@ -534,6 +689,39 @@ class MeshConverter(_MeshManager):
                     uvMap[numUVs - 2].normalize()
                     uvMap[numUVs - 1].normalize()
                     vtx.uvs = uvMap
+
+            if export_deform:
+                # MaxBoneIdx and PenBoneIdx: these are the indices of the two highest-weighted bones on the mesh.
+                # Plasma will use those to compute a bounding box for the deformed object at run-time,
+                # in order to clip them when outside the view frustum.
+                # (The new BB is computed by extending the base BB with two versions of itself transformed by the max/pen bones).
+                # See plDrawableSpans::IUpdateMatrixPaletteBoundsHack.
+                # This is... about as reliable as you can expect: it kinda works, it's not great. This will have to do for now.
+                # (If you ask me, I'd rip the entire thing out and just not clip anything, framerate be damned.)
+                # Note that max/pen bones are determined by how many vertices they deform, which is a bit different (and more efficient)
+                # than whatever the Max plugin does in plMAXVertexAccumulator::StuffMyData.
+                sorted_ids_by_weight = sorted(((weight, id) for id, weight in data.total_weight_by_bones.items()), reverse = True)
+                # We should be guaranteed to have at least two bones - there are no armatures with no bones (...right?),
+                # and there is always the null bone if we really have nothing else.
+                geospan.maxBoneIdx = sorted_ids_by_weight[0][1]
+                geospan.penBoneIdx = sorted_ids_by_weight[1][1]
+
+                # This is also a good time to specify how many bones per vertices we allow, for optimization purposes.
+                max_deform_bones = data.max_deform_bones
+                if max_deform_bones == 3:
+                    geospan.format |= plGeometrySpan.kSkin3Weights | plGeometrySpan.kSkinIndices
+                elif max_deform_bones == 2:
+                    geospan.format |= plGeometrySpan.kSkin2Weights | plGeometrySpan.kSkinIndices
+                else: # max_bones_per_vert == 1
+                    geospan.format |= plGeometrySpan.kSkin1Weight
+                    if len(group_id_to_bone_id) > 1:
+                        geospan.format |= plGeometrySpan.kSkinIndices
+                    else:
+                        # No skin indices required... BUT! We have assigned some weight to the null bone on top of the only bone, so we need to fix that.
+                        for vtx in data.vertices:
+                            weight = vtx.weights[0]
+                            weight = 1 - weight
+                            vtx.weights = (weight, 0.0, 0.0)
 
             # If we're still here, let's add our data to the GeometrySpan
             geospan.indices = data.triangles
@@ -636,9 +824,13 @@ class MeshConverter(_MeshManager):
             dspan = self._find_create_dspan(bo, i.geospan, i.pass_index)
             self._report.msg("Exported hsGMaterial '{}' geometry into '{}'",
                              i.geospan.material.name, dspan.key.name)
+            armatures = self._objects_armatures.get(bo.name)
             idx = dspan.addSourceSpan(i.geospan)
             diidx = _diindices.setdefault(dspan, [])
             diidx.append(idx)
+            if armatures is not None:
+                bone_id_to_name = {group.index: group.name for group in bo.vertex_groups}
+                self._geospans_armatures[(dspan, idx)] = (armatures, bone_id_to_name)
 
         # Step 3.1: Harvest Span indices and create the DIIndices
         drawables = []

--- a/korman/helpers.py
+++ b/korman/helpers.py
@@ -18,6 +18,7 @@ import bpy
 from contextlib import contextmanager
 import math
 from typing import *
+from uuid import uuid4
 
 @contextmanager
 def bmesh_from_object(bl):
@@ -64,12 +65,14 @@ class GoodNeighbor:
 @contextmanager
 def TemporaryCollectionItem(collection):
     item = collection.add()
+    # Blender may recreate the `item` instance as the collection grows and shrink...
+    # Assign it a unique name so we know which item to delete later on.
+    name = item.name = str(uuid4())
     try:
         yield item
     finally:
-        index = next((i for i, j in enumerate(collection) if j == item), None)
-        if index is not None:
-            collection.remove(index)
+        index = collection.find(name)
+        collection.remove(index)
 
 class TemporaryObject:
     def __init__(self, obj, remove_func):

--- a/korman/helpers.py
+++ b/korman/helpers.py
@@ -45,8 +45,10 @@ def copy_object(bl, name: Optional[str] = None):
 class GoodNeighbor:
     """Leave Things the Way You Found Them! (TM)"""
 
-    def __enter__(self):
+    def __init__(self):
         self._tracking = {}
+
+    def __enter__(self):
         return self
 
     def track(self, cls, attr, value):

--- a/korman/properties/modifiers/anim.py
+++ b/korman/properties/modifiers/anim.py
@@ -99,8 +99,9 @@ class PlasmaAnimationModifier(ActionModifier, PlasmaModifierProperties):
                 start, end = min((start, end)), max((start, end))
             else:
                 start, end = None, None
+            bake_frame_step = anim.bake_frame_step if anim.bake else None
 
-            applicators = converter.convert_object_animations(bo, so, anim_name, start=start, end=end)
+            applicators = converter.convert_object_animations(bo, so, anim_name, start=start, end=end, bake_frame_step=bake_frame_step)
             if not applicators:
                 exporter.report.warn(f"Animation '{anim_name}' generated no applicators. Nothing will be exported.")
                 continue

--- a/korman/properties/prop_anim.py
+++ b/korman/properties/prop_anim.py
@@ -127,6 +127,29 @@ class PlasmaAnimation(bpy.types.PropertyGroup):
                 bpy.types.Texture: "plasma_layer.anim_loop_end",
             },
         },
+        "bake": {
+            "type": BoolProperty,
+            "property": {
+                "name": "Bake Keyframes",
+                "description": "Bake animation keyframes on export. This generates a lot more intermediary keyframes but allows exporting inverse kinematics, and may improve timing for complex animations",
+                "default": False,
+            },
+            "entire_animation": {
+                bpy.types.Object: "plasma_modifiers.animation.bake",
+            },
+        },
+        "bake_frame_step": {
+            "type": IntProperty,
+            "property": {
+                "name": "Frame step",
+                "description": "How many frames between each keyframe sample",
+                "default": 1,
+                "min": 1,
+            },
+            "entire_animation": {
+                bpy.types.Object: "plasma_modifiers.animation.bake_frame_step",
+            },
+        },
         "sdl_var": {
             "type": StringProperty,
             "property": {

--- a/korman/render.py
+++ b/korman/render.py
@@ -40,6 +40,7 @@ from bl_ui import properties_data_mesh
 properties_data_mesh.DATA_PT_normals.COMPAT_ENGINES.add("PLASMA_GAME")
 properties_data_mesh.DATA_PT_uv_texture.COMPAT_ENGINES.add("PLASMA_GAME")
 properties_data_mesh.DATA_PT_vertex_colors.COMPAT_ENGINES.add("PLASMA_GAME")
+properties_data_mesh.DATA_PT_vertex_groups.COMPAT_ENGINES.add("PLASMA_GAME")
 del properties_data_mesh
 
 def _whitelist_all(mod):

--- a/korman/ui/ui_anim.py
+++ b/korman/ui/ui_anim.py
@@ -67,6 +67,11 @@ def draw_single_animation(layout, anim):
             col.active = anim.loop and not anim.sdl_var
             col.prop_search(anim, "loop_start", action, "pose_markers", icon="PMARKER")
             col.prop_search(anim, "loop_end", action, "pose_markers", icon="PMARKER")
+            layout.separator()
+            split = layout.split()
+            split.prop(anim, "bake")
+            if anim.bake:
+                split.prop(anim, "bake_frame_step")
 
     layout.separator()
     layout.prop(anim, "sdl_var")


### PR DESCRIPTION
Alright, this is a big one. I probably won't have a lot of time to implement suggestions until the RAD is over, so feel free to take your time reviewing. I also didn't check how optimized the code is (especially regarding Python generators), suggestions are welcome.

The first thing that needs to be mentioned: I decided to let Korman generate a LOT of temporary Blender objects during export. This may feel messy, but I've rewritten the code several times and AFAICT is still the best solution. Temporary objects should all get cleaned up nicely whatever happens.

Second, there are still two small problems, that I'll get around to later:
- Warning messages about "Animation generated no applicators" - harmless.
- Exported skinned objects don't automatically get runtime lighting. This can be forced using a Lighting Info modifier, but it might be worth making it automatic just like other animated objects.

---

**Armatures**
- Armature objects are exported as regular `SceneObjects`.
- Each bone of the armature is exported as two (!) new `SceneObjects`. Bone hierarchy is respected.
- The two `SceneObjects` are: the rest position of the bone, and the actual deform bone. For instance, the following bone hierarchy:
    - Armature:
        - Bone1
            - Bone2
        - Bone3
- ...Will be exported as:
    - Armature:
        - Bone1_REST
            - Bone1
                - Bone2_REST
                    - Bone2
        - Bone3_REST
            - Bone3
- Exporting two `SceneObjects` per bone avoids a whole slew of problems when exporting animations. Otherwise we'd be running in the same problem as an object having a `matrix_parent_inverse`.
- For various reasons, those two bone objects are actually temporary Blender Empty objects that are created at export-time. (I rewrote this several times, but in the end this felt like the best solution.) (On cleanup: those empties are deleted.)


**Animations**
- Armatures with an Animation modifier automatically get their Animation Group modifier toggled on during export. (On cleanup: modifier gets re-disabled if necessary.)
- Animated bones generate two Empty objects as previously mentioned - one of those empties gets to be animated:
    - The bone's animations are copied to a temporary Action assigned to the empty object. (Cleanup: the Action is deleted.)
    - An Animation modifier that matches the armature's own is added to the empty object. This Animation modifier is referenced in the armature's own Animation Group modifier. (On cleanup: the reference is removed.)
- This means one can easily play specific armature animations from nodes/responders, as Korman will reroute those messages to the armature's Animation Group / `plMsgForwarder`.
- Note that just like Cyan, we generate one `plATCAnim` per bone, per animation. Ideally we would group all bones in a single `plATCAnim`, but in my tests this doesn't work - seems it's only available to special objects like avatars.
- Animation modifiers now have two extra properties to bake animations.
    - Baking is required to get bone inverse kinematic (IK) to export.
    - It also helps fix some occasional animations issues: wrong tangents, missing keyframes on armature bones, etc. For this reason, it's also available to regular animations.
    - Baking is neither a silver bullet (can worsen animations), nor cheap (takes a long time to compute), so it is disabled by default. It's up to the user to know when to enable it.


**Rigged/deformed meshes**
- If the armature itself is not exported, the modifier/pose will be baked in the mesh and no expensive runtime deformation happens. (This is useful to make variations of the same mesh. For instance: trees with different branch shapes and sizes.)
- Otherwise, the armature modifier is disabled (so it doesn't get baked into the mesh), and weight/indices are exported in the mesh's vertices. (On cleanup: modifier is reenabled.)
    - Vertices that are not deformed by any bone get assigned to a special "null" bone that never moves. This is very commonly used in Kemo for trees, since their roots don't move.
    - If possible, less than 3 skin indices will be used per vertex for better performances.
- When generating the Drawable Spans from the collection of Geometry Spans, a few things need to happen.
    - Bone transforms get added to the DSpan, and bones get a Draw Interface referencing said bone.
    - Icicles get adjusted matrix indices so they know which bones they are using.
- Worth noting that Blender objects can have multiple Armature modifiers. This is accepted by Korman, but results are completely untested.
- Rigged meshes do NOT get a `CoordinateInterface`, ever. Since people usually parent the rigged mesh to the armature itself, Korman will simply ignore that relationship on export.
    - The reason for this is armature sharing. Armatures can be shared between rigs in Blender, but the way `DrawableSpans` work, this would require duplicating the bones for each object, so screw that.
    - There is rarely a good reason for the object to have its own coordinate system since it's supposed to move with the armature anyway... (except maybe floating-point precision ?)


**Other**
- Regular (non deformable) objects can now be parented to armature bones. This provides an easy way to use IK for machines and the like, without the overhead of deforming the vertices.


Backwards compatibility: completely new feature so no problem expected unless I messed up. It does fix a bug with `TemporaryCollectionItem` though.


And here is a [test file](https://www.dropbox.com/scl/fi/pr4eklxlrbgc8rl9udwhm/armature_testfile.blend?rlkey=n83rxpiesqljf1spc0dj8y9mb&st=n8ta659n&dl=1) so you can see it in action.