### PR TITLE
Fix TemporaryCollectionItem reference bug

### DIFF
--- a/korman/helpers.py
+++ b/korman/helpers.py
@@ -62,12 +62,14 @@ class GoodNeighbor:
 @contextmanager
 def TemporaryCollectionItem(collection):
     item = collection.add()
+    # Blender may recreate the `item` instance as the collection grows and shrink...
+    # Assign it a unique name so we know which item to delete later on.
+    name = item.name = str(uuid4())
     try:
         yield item
     finally:
-        index = next((i for i, j in enumerate(collection) if j == item), None)
-        if index is not None:
-            collection.remove(index)
+        index = collection.find(name)
+        collection.remove(index)
 
 class TemporaryObject:
     def __init__(self, obj, remove_func):


### PR DESCRIPTION
Taken from #436. Fixes a random bug with `TemporaryCollectionItem`, where temporary items don't get cleaned up after export due to collection reallocation. So far I think it's only been used to generate extra sounds at export time, so it flew under the radar, but it happens very often with armatures.