### PR TITLE
Implement Many, Many Game GUI Controls

### DIFF
--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -133,6 +133,15 @@ def poll_empty_objects(self, value):
 def poll_mesh_objects(self, value):
     return value.type == "MESH"
 
+def poll_object_dyntexts(self, value):
+    if value.type != "IMAGE":
+        return False
+    if value.image is not None:
+        return False
+    tex_materials = frozenset(value.users_material)
+    obj_materials = frozenset(filter(None, (i.material for i in self.id_data.material_slots)))
+    return bool(tex_materials & obj_materials)
+
 def poll_softvolume_objects(self, value):
     return value.plasma_modifiers.softvolume.enabled
 

--- a/korman/idprops.py
+++ b/korman/idprops.py
@@ -142,6 +142,13 @@ def poll_object_dyntexts(self, value):
     obj_materials = frozenset(filter(None, (i.material for i in self.id_data.material_slots)))
     return bool(tex_materials & obj_materials)
 
+def poll_object_image_textures(self, value):
+    if value.type != "IMAGE":
+        return False
+    tex_materials = frozenset(value.users_material)
+    obj_materials = frozenset(filter(None, (i.material for i in self.id_data.material_slots)))
+    return bool(tex_materials & obj_materials)
+
 def poll_softvolume_objects(self, value):
     return value.plasma_modifiers.softvolume.enabled
 

--- a/korman/operators/op_toolbox.py
+++ b/korman/operators/op_toolbox.py
@@ -160,6 +160,24 @@ class PlasmaSelectPageObjectsOperator(PageSearchOperator, bpy.types.Operator):
         return {"FINISHED"}
 
 
+class PlasmaSelectRadioGroupCheckboxesOperator(bpy.types.Operator):
+    bl_idname = "object.plasma_select_radio_group"
+    bl_label = "Select Radio Group"
+    bl_description = "Selects all checkboxes in a radio group"
+
+    def execute(self, context):
+        active_object = context.active_object
+        for i in context.scene.objects:
+            cb_mod = i.plasma_modifiers.gui_checkbox
+            cb_rg = cb_mod.radio_group
+            i.select = (
+                (cb_mod.enabled and cb_rg is not None and cb_rg.name == active_object.name)
+                or
+                (i.name == active_object.name)
+            )
+        return {"FINISHED"}
+
+
 class PlasmaToggleAllPlasmaObjectsOperator(ToolboxOperator, bpy.types.Operator):
     bl_idname = "object.plasma_toggle_all_objects"
     bl_label = "Toggle All Plasma Objects"

--- a/korman/properties/modifiers/__init__.py
+++ b/korman/properties/modifiers/__init__.py
@@ -27,6 +27,17 @@ from .render import *
 from .sound import *
 from .water import *
 
+# Check our mixins to ensure that the subclasses have them first in their MRO.
+_mod_mixins = [game_gui._GameGuiMixin]
+for mixin in _mod_mixins:
+    for sub in mixin.__subclasses__():
+        mro = sub.__mro__
+        if mro.index(mixin) > mro.index(PlasmaModifierProperties):
+            raise ImportError(
+                f"{sub.__name__} base class {mixin.__name__} isn't properly "
+                "overriding PlasmaModifierProperties!"
+                )
+
 class PlasmaModifiers(bpy.types.PropertyGroup):
     def determine_next_id(self):
         """Gets the ID for the next modifier in the UI"""

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -372,6 +372,34 @@ class PlasmaGameGuiButtonModifier(PlasmaModifierProperties, _GameGuiMixin):
         self.mouse_click_anims.export(exporter, bo, so, ctrl, ctrl.addAnimationKey, "animName")
 
 
+class PlasamGameGuiClickMapModifier(PlasmaModifierProperties, _GameGuiMixin):
+    pl_id = "gui_clickmap"
+    pl_depends = {"gui_control"}
+    pl_page_types = {"gui"}
+
+    bl_category = "GUI"
+    bl_label = "GUI ClickMap (ex)"
+    bl_description = "XXX"
+
+    report_while: Set[str] = EnumProperty(
+        name="Report While",
+        description="",
+        items=[
+            ("kMouseDragged", "Dragging", ""),
+            ("kMouseHovered", "Hovering", ""),
+        ],
+        options={"ENUM_FLAG"}
+    )
+
+    def get_control(self, exporter: Exporter, bo: Optional[bpy.types.Object] = None, so: Optional[plSceneObject] = None) -> pfGUIClickMapCtrl:
+        return exporter.mgr.find_create_object(pfGUIClickMapCtrl, bl=bo, so=so)
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        ctrl = self.get_control(exporter, bo, so)
+        for report in self.report_while:
+            ctrl.setFlag(getattr(pfGUIClickMapCtrl, report), True)
+
+
 class PlasmaGameGuiDialogModifier(PlasmaModifierProperties, _GameGuiMixin):
     pl_id = "gui_dialog"
     pl_page_types = {"gui"}

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -269,7 +269,8 @@ class PlasmaGameGuiControlModifier(_GameGuiMixin, PlasmaModifierProperties):
     bl_category = "GUI"
     bl_label = "GUI Control (ex)"
     bl_description = "XXX"
-    bl_object_types = {"FONT", "MESH"}
+    bl_object_types = {"EMPTY", "FONT", "MESH"}
+    bl_icon = "FULLSCREEN"
 
     tag_id = IntProperty(
         name="Tag ID",

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -34,9 +34,9 @@ if TYPE_CHECKING:
 
 class _GameGuiMixin:
     @property
-    def gui_sounds(self) -> Iterable[Tuple[str, int]]:
-        """Overload to automatically export GUI sounds on the control. This should return an iterable
-           of tuple attribute name and sound index.
+    def gui_sounds(self) -> Dict[str, int]:
+        """Overload to automatically export GUI sounds on the control.
+           This should return a dict of string attribute names to indices.
         """
         return []
 
@@ -91,7 +91,7 @@ class _GameGuiMixin:
 
         # Blow up on invalid sounds
         soundemit = self.id_data.plasma_modifiers.soundemit
-        for attr_name, _ in self.gui_sounds:
+        for attr_name in self.gui_sounds:
             sound_name = getattr(self, attr_name)
             if not sound_name:
                 continue
@@ -158,7 +158,7 @@ class PlasmaGameGuiControlModifier(PlasmaModifierProperties, _GameGuiMixin):
         # NOTE that zero is a special value here meaning no sound, so we need to offset the sounds
         # that we get from the emitter modifier by +1.
         sound_indices = {}
-        for attr_name, gui_sound_idx in ctrl_mod.gui_sounds:
+        for attr_name, gui_sound_idx in ctrl_mod.gui_sounds.items():
             sound_name = getattr(ctrl_mod, attr_name)
             if not sound_name:
                 continue
@@ -344,13 +344,13 @@ class PlasmaGameGuiButtonModifier(PlasmaModifierProperties, _GameGuiMixin):
     )
 
     @property
-    def gui_sounds(self):
-        return (
-            ("mouse_down_sound", pfGUIButtonMod.kMouseDown),
-            ("mouse_up_sound", pfGUIButtonMod.kMouseUp),
-            ("mouse_over_sound", pfGUIButtonMod.kMouseOver),
-            ("mouse_off_sound", pfGUIButtonMod.kMouseOff),
-        )
+    def gui_sounds(self) -> Dict[str, int]:
+        return {
+            "mouse_down_sound": pfGUIButtonMod.kMouseDown,
+            "mouse_up_sound": pfGUIButtonMod.kMouseUp,
+            "mouse_over_sound": pfGUIButtonMod.kMouseOver,
+            "mouse_off_sound": pfGUIButtonMod.kMouseOff,
+        }
 
     def get_control(self, exporter: Exporter, bo: Optional[bpy.types.Object] = None, so: Optional[plSceneObject] = None) -> pfGUIButtonMod:
         return exporter.mgr.find_create_object(pfGUIButtonMod, bl=bo, so=so)

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -479,6 +479,7 @@ class PlasmaGameGuiButtonModifier(_GameGuiMixin, PlasmaModifierProperties):
     bl_category = "GUI"
     bl_label = "GUI Button (ex)"
     bl_description = "XXX"
+    bl_icon = "BUTS"
     bl_object_types = {"FONT", "MESH"}
 
     def _update_notify_type(self, context):
@@ -565,6 +566,7 @@ class PlasmaGameGuiCheckBoxModifier(_GameGuiMixin, PlasmaModifierProperties):
     bl_category = "GUI"
     bl_label = "GUI Checkbox (ex)"
     bl_description = "XXX"
+    bl_icon = "CHECKBOX_HLT"
     bl_object_types = {"MESH"}
 
     def _update_notify_type(self, context):
@@ -634,6 +636,7 @@ class PlasamGameGuiClickMapModifier(_GameGuiMixin, PlasmaModifierProperties):
     bl_category = "GUI"
     bl_label = "GUI ClickMap (ex)"
     bl_description = "XXX"
+    bl_icon = "HAND"
 
     report_while: Set[str] = EnumProperty(
         name="Report While",
@@ -767,6 +770,7 @@ class PlasmaGameGuiDialogModifier(_GameGuiMixin, PlasmaModifierProperties):
     bl_category = "GUI"
     bl_label = "GUI Dialog (ex)"
     bl_description = "XXX"
+    bl_icon = "SPLITSCREEN"
 
     camera_object: bpy.types.Object = PointerProperty(
         name="GUI Camera",

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -34,6 +34,12 @@ if TYPE_CHECKING:
 
 class _GameGuiMixin:
     @property
+    def copy_material(self) -> bool:
+        # If this control uses a dynamic text map, then its contents are unique.
+        # Therefore, we need to copy the material.
+        return self.requires_dyntext
+
+    @property
     def gui_sounds(self) -> Dict[str, int]:
         """Overload to automatically export GUI sounds on the control.
            This should return a dict of string attribute names to indices.
@@ -100,7 +106,7 @@ class _GameGuiMixin:
                 raise ExportError(f"'{self.id_data.name}': Invalid '{attr_name}' GUI Sound '{sound_name}'")
 
 
-class PlasmaGameGuiControlModifier(PlasmaModifierProperties, _GameGuiMixin):
+class PlasmaGameGuiControlModifier(_GameGuiMixin, PlasmaModifierProperties):
     pl_id = "gui_control"
     pl_page_types = {"gui"}
 
@@ -287,7 +293,7 @@ class GameGuiAnimationGroup(bpy.types.PropertyGroup):
                 add_func(i)
 
 
-class PlasmaGameGuiButtonModifier(PlasmaModifierProperties, _GameGuiMixin):
+class PlasmaGameGuiButtonModifier(_GameGuiMixin, PlasmaModifierProperties):
     pl_id = "gui_button"
     pl_depends = {"gui_control"}
     pl_page_types = {"gui"}
@@ -373,7 +379,7 @@ class PlasmaGameGuiButtonModifier(PlasmaModifierProperties, _GameGuiMixin):
 
 
 
-class PlasmaGameGuiCheckBoxModifier(PlasmaModifierProperties, _GameGuiMixin):
+class PlasmaGameGuiCheckBoxModifier(_GameGuiMixin, PlasmaModifierProperties):
     pl_id = "gui_checkbox"
     pl_depends = {"gui_control"}
     pl_page_types = {"gui"}
@@ -442,7 +448,7 @@ class PlasmaGameGuiCheckBoxModifier(PlasmaModifierProperties, _GameGuiMixin):
         self.anims.export(exporter, bo, so, ctrl, ctrl.addAnimKey, "animName")
 
 
-class PlasamGameGuiClickMapModifier(PlasmaModifierProperties, _GameGuiMixin):
+class PlasamGameGuiClickMapModifier(_GameGuiMixin, PlasmaModifierProperties):
     pl_id = "gui_clickmap"
     pl_depends = {"gui_control"}
     pl_page_types = {"gui"}
@@ -470,7 +476,7 @@ class PlasamGameGuiClickMapModifier(PlasmaModifierProperties, _GameGuiMixin):
             ctrl.setFlag(getattr(pfGUIClickMapCtrl, report), True)
 
 
-class PlasmaGameGuiDragBarModifier(PlasmaModifierProperties, _GameGuiMixin):
+class PlasmaGameGuiDragBarModifier(_GameGuiMixin, PlasmaModifierProperties):
     pl_id = "gui_dragbar"
     pl_depends = {"gui_control"}
     pl_page_types = {"gui"}
@@ -491,7 +497,7 @@ class PlasmaGameGuiDragBarModifier(PlasmaModifierProperties, _GameGuiMixin):
         return True
 
 
-class PlasmaGameGuiDialogModifier(PlasmaModifierProperties, _GameGuiMixin):
+class PlasmaGameGuiDialogModifier(_GameGuiMixin, PlasmaModifierProperties):
     pl_id = "gui_dialog"
     pl_page_types = {"gui"}
 

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -470,6 +470,27 @@ class PlasamGameGuiClickMapModifier(PlasmaModifierProperties, _GameGuiMixin):
             ctrl.setFlag(getattr(pfGUIClickMapCtrl, report), True)
 
 
+class PlasmaGameGuiDragBarModifier(PlasmaModifierProperties, _GameGuiMixin):
+    pl_id = "gui_dragbar"
+    pl_depends = {"gui_control"}
+    pl_page_types = {"gui"}
+
+    bl_category = "GUI"
+    bl_label = "GUI Drag Bar (ex)"
+    bl_description = "XXX"
+
+    def get_control(self, exporter: Exporter, bo: Optional[bpy.types.Object] = None, so: Optional[plSceneObject] = None) -> pfGUIDragBarCtrl:
+        return exporter.mgr.find_create_object(pfGUIDragBarCtrl, bl=bo, so=so)
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        ctrl = self.get_control(exporter, bo, so)
+        ctrl.setFlag(pfGUIControlMod.kBetterHitTesting, True)
+
+    @property
+    def requires_actor(self):
+        return True
+
+
 class PlasmaGameGuiDialogModifier(PlasmaModifierProperties, _GameGuiMixin):
     pl_id = "gui_dialog"
     pl_page_types = {"gui"}

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -68,7 +68,7 @@ class _GameGuiMixin:
         """Overload to automatically export GUI sounds on the control.
            This should return a dict of string attribute names to indices.
         """
-        return []
+        return {}
 
     def get_control(self, exporter: Exporter, bo: Optional[bpy.types.Object] = None, so: Optional[plSceneObject] = None) -> Optional[pfGUIControlMod]:
         return None
@@ -266,7 +266,7 @@ class PlasmaGameGuiControlModifier(_GameGuiMixin, PlasmaModifierProperties):
         description="",
         default=True,
         options=set()
-        )
+    )
     proc = EnumProperty(
         name="Notification Procedure",
         description="",
@@ -304,6 +304,8 @@ class PlasmaGameGuiControlModifier(_GameGuiMixin, PlasmaModifierProperties):
             handler = pfGUIConsoleCmdProc()
             handler.command = self.console_command
             ctrl.handler = handler
+        else:
+            raise ValueError(self.proc)
 
     def convert_gui_sounds(self, exporter: Exporter, ctrl: pfGUIControlMod, ctrl_mod: _GameGuiMixin):
         soundemit = ctrl_mod.id_data.plasma_modifiers.soundemit

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -372,6 +372,76 @@ class PlasmaGameGuiButtonModifier(PlasmaModifierProperties, _GameGuiMixin):
         self.mouse_click_anims.export(exporter, bo, so, ctrl, ctrl.addAnimationKey, "animName")
 
 
+
+class PlasmaGameGuiCheckBoxModifier(PlasmaModifierProperties, _GameGuiMixin):
+    pl_id = "gui_checkbox"
+    pl_depends = {"gui_control"}
+    pl_page_types = {"gui"}
+
+    bl_category = "GUI"
+    bl_label = "GUI Checkbox (ex)"
+    bl_description = "XXX"
+    bl_object_types = {"MESH"}
+
+    def _update_notify_type(self, context):
+        # It doesn't make sense to have no notify type at all selected, so
+        # default to at least one option.
+        if not self.notify_type:
+            self.notify_type = {"DOWN"}
+
+    anims: GameGuiAnimationGroup = PointerProperty(type=GameGuiAnimationGroup)
+    show_expanded_sounds: bool = BoolProperty(options={"HIDDEN"})
+
+    checked: bool = BoolProperty(
+        name="Checked by Default",
+        description="Does the checkbox default to checked?",
+        options=set()
+    )
+
+    mouse_down_sound: str = StringProperty(
+        name="Mouse Down SFX",
+        description="Sound played when the mouse button is down",
+        options=set()
+    )
+
+    mouse_up_sound: str = StringProperty(
+        name="Mouse Up SFX",
+        description="Sound played when the mouse button is released",
+        options=set()
+    )
+
+    mouse_over_sound: str = StringProperty(
+        name="Mouse Over SFX",
+        description="Sound played when the mouse moves over the GUI button",
+        options=set()
+    )
+
+    mouse_off_sound: str = StringProperty(
+        name="Mouse Off SFX",
+        description="Sound played when the mouse moves off of the GUI button",
+        options=set()
+    )
+
+    @property
+    def gui_sounds(self) -> Dict[str, int]:
+        return {
+            "mouse_down_sound": pfGUICheckBoxCtrl.kMouseDown,
+            "mouse_up_sound": pfGUICheckBoxCtrl.kMouseUp,
+            "mouse_over_sound": pfGUICheckBoxCtrl.kMouseOver,
+            "mouse_off_sound": pfGUICheckBoxCtrl.kMouseOff,
+        }
+
+    def get_control(self, exporter: Exporter, bo: Optional[bpy.types.Object] = None, so: Optional[plSceneObject] = None) -> pfGUICheckBoxCtrl:
+        return exporter.mgr.find_create_object(pfGUICheckBoxCtrl, bl=bo, so=so)
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        ctrl = self.get_control(exporter, bo, so)
+        ctrl.setFlag(pfGUIControlMod.kWantsInterest, True)
+        ctrl.checked = self.checked
+
+        self.anims.export(exporter, bo, so, ctrl, ctrl.addAnimKey, "animName")
+
+
 class PlasamGameGuiClickMapModifier(PlasmaModifierProperties, _GameGuiMixin):
     pl_id = "gui_clickmap"
     pl_depends = {"gui_control"}

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -645,19 +645,10 @@ class PlasmaLocalizedTextModifier(PlasmaModifierProperties, PlasmaModifierLogicW
                                       set=TranslationMixin._set_translation,
                                       options=set())
 
-    def _poll_dyna_text(self, value: bpy.types.Texture) -> bool:
-        if value.type != "IMAGE":
-            return False
-        if value.image is not None:
-            return False
-        tex_materials = frozenset(value.users_material)
-        obj_materials = frozenset(filter(None, (i.material for i in self.id_data.material_slots)))
-        return bool(tex_materials & obj_materials)
-
     texture = PointerProperty(name="Texture",
                               description="The texture to write the localized text on",
                               type=bpy.types.Texture,
-                              poll=_poll_dyna_text)
+                              poll=idprops.poll_object_dyntexts)
 
     font_face = StringProperty(name="Font Face",
                                default="Arial",

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -624,7 +624,7 @@ class PlasmaLightingMod(PlasmaModifierProperties):
         return False
 
 
-class PlasmaLocalizedTextModifier(PlasmaModifierProperties, PlasmaModifierLogicWiz, TranslationMixin):
+class PlasmaLocalizedTextModifier(TranslationMixin, PlasmaModifierProperties, PlasmaModifierLogicWiz):
     pl_id = "dynatext"
     pl_page_types = {"gui", "room"}
 

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -192,6 +192,13 @@ def gui_dynamic_display(modifier: PlasmaGameGuiDynamicDisplayModifier, layout, c
     layout.alert = modifier.texture is None
     layout.prop(modifier, "texture")
 
+def gui_input(modifier: PlasmaGameGuiInputBoxModifier, layout, context):
+    layout.prop(modifier, "lines")
+
+    row = layout.row()
+    row.active = modifier.lines == "multi"
+    row.prop(modifier, "scroll_control", icon="LINENUMBERS_ON")
+
 def gui_progress(modifier: PlasmaGameGuiProgressControlModifier, layout, context):
     layout.prop(modifier, "direction")
     _gui_anim("Animation", modifier.anims, layout, context)

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -114,6 +114,21 @@ def gui_button(modifier, layout, context):
         }
     )
 
+def gui_checkbox(modifier: PlasmaGameGuiCheckBoxModifier, layout, context):
+    layout.prop(modifier, "checked")
+
+    _gui_anim("Check", modifier.anims, layout, context)
+
+    _gui_sounds(
+        modifier, layout, context,
+        {
+            "mouse_down_sound": "Mouse Down",
+            "mouse_up_sound": "Mouse Up",
+            "mouse_over_sound": "Mouse Over",
+            "mouse_off_sound": "Mouse Off",
+        }
+    )
+
 def gui_clickmap(modifier: PlasamGameGuiClickMapModifier, layout, context):
     sub = layout.row()
     sub.label("Report When:")

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -21,7 +21,7 @@ import bpy.types
 from .. import ui_list
 
 if TYPE_CHECKING:
-    from ...properties.modifiers.game_gui import GameGuiAnimation, GameGuiAnimationGroup
+    from ...properties.modifiers.game_gui import *
 
 class GuiAnimListUI(bpy.types.UIList):
     def _iter_target_names(self, item: GameGuiAnimation):
@@ -93,6 +93,11 @@ def gui_button(modifier, layout, context):
         col.prop_search(modifier, "mouse_up_sound", soundemit, "sounds", text="Mouse Up", icon="SPEAKER")
         col.prop_search(modifier, "mouse_over_sound", soundemit, "sounds", text="Mouse Over", icon="SPEAKER")
         col.prop_search(modifier, "mouse_off_sound", soundemit, "sounds", text="Mouse Off", icon="SPEAKER")
+
+def gui_clickmap(modifier: PlasamGameGuiClickMapModifier, layout, context):
+    sub = layout.row()
+    sub.label("Report When:")
+    sub.prop(modifier, "report_while")
 
 def gui_control(modifier, layout, context):
     split = layout.split()

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -179,6 +179,19 @@ def gui_control(modifier, layout, context):
 def gui_dragbar(modifier: PlasmaGameGuiDragBarModifier, layout, context):
     layout.label("Drag Bars have no settings.")
 
+def gui_textbox(modifier: PlasmaGameGuiTextBoxModifier, layout, context):
+    layout.prop(modifier, "justification")
+
+    sub = layout.column()
+    sub.prop(modifier, "active_translation")
+    try:
+        translation = modifier.text_translations[modifier.active_translation_index]
+    except Exception as e:
+        sub.label(text="Error (see console)", icon="ERROR")
+        print(e)
+    else:
+        sub.prop(translation, "value")
+
 def gui_dialog(modifier, layout, context):
     row = layout.row(align=True)
     row.prop(modifier, "camera_object")

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -143,6 +143,11 @@ def gui_control(modifier, layout, context):
     col.prop(modifier, "tag_id")
 
     col = layout.column()
+    col.active = modifier.requires_dyntext
+    col.alert = modifier.requires_dyntext and modifier.texture is None
+    col.prop(modifier, "texture")
+
+    col = layout.column()
     col.active = modifier.has_gui_proc
     col.prop(modifier, "proc")
     row = col.row()

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -188,6 +188,16 @@ def gui_dynamic_display(modifier: PlasmaGameGuiDynamicDisplayModifier, layout, c
     layout.alert = modifier.texture is None
     layout.prop(modifier, "texture")
 
+def gui_progress(modifier: PlasmaGameGuiProgressControlModifier, layout, context):
+    layout.prop(modifier, "direction")
+    _gui_anim("Animation", modifier.anims, layout, context)
+    _gui_sounds(
+        modifier, layout, context,
+        {
+            "animate_sound": "Animation",
+        }
+    )
+
 def gui_radio_group(modifier: PlasmaGameGuiRadioGroupModifier, layout, context):
     layout.operator("object.plasma_select_radio_group", icon="RESTRICT_SELECT_OFF")
     layout.prop(modifier, "allow_no_selection")
@@ -204,6 +214,13 @@ def gui_textbox(modifier: PlasmaGameGuiTextBoxModifier, layout, context):
         print(e)
     else:
         sub.prop(translation, "value")
+
+def gui_value(modifier: PlasmaGameGuiValueControlModifier, layout, context):
+    row = layout.row(align=True)
+    row.alert = modifier.min_value >= modifier.max_value
+    row.prop(modifier, "min_value")
+    row.prop(modifier, "step")
+    row.prop(modifier, "max_value")
 
 def gui_dialog(modifier, layout, context):
     row = layout.row(align=True)

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -134,6 +134,28 @@ def gui_clickmap(modifier: PlasamGameGuiClickMapModifier, layout, context):
     sub.label("Report When:")
     sub.prop(modifier, "report_while")
 
+def gui_colorscheme(
+    modifier: PlasmaGameGuiColorSchemeModifier,
+    layout: bpy.types.UILayout,
+    context: bpy.types.Context
+) -> None:
+    split = layout.split()
+
+    col = split.column()
+    col.prop(modifier, "foreground_color")
+    col.prop(modifier, "background_color")
+
+    col = split.column()
+    col.prop(modifier, "selection_foreground_color")
+    col.prop(modifier, "selection_background_color")
+
+    layout.separator()
+    layout.prop(modifier, "font_face")
+
+    row = layout.row()
+    row.prop_menu_enum(modifier, "font_style")
+    row.prop(modifier, "font_size")
+
 def gui_control(modifier, layout, context):
     split = layout.split()
     col = split.column()

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -115,6 +115,7 @@ def gui_button(modifier, layout, context):
     )
 
 def gui_checkbox(modifier: PlasmaGameGuiCheckBoxModifier, layout, context):
+    layout.prop(modifier, "radio_group", icon="RADIOBUT_ON")
     layout.prop(modifier, "checked")
 
     _gui_anim("Check", modifier.anims, layout, context)
@@ -178,6 +179,10 @@ def gui_control(modifier, layout, context):
 
 def gui_dragbar(modifier: PlasmaGameGuiDragBarModifier, layout, context):
     layout.label("Drag Bars have no settings.")
+
+def gui_radio_group(modifier: PlasmaGameGuiRadioGroupModifier, layout, context):
+    layout.operator("object.plasma_select_radio_group", icon="RESTRICT_SELECT_OFF")
+    layout.prop(modifier, "allow_no_selection")
 
 def gui_textbox(modifier: PlasmaGameGuiTextBoxModifier, layout, context):
     layout.prop(modifier, "justification")

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -171,6 +171,10 @@ def gui_control(modifier, layout, context):
     col.prop(modifier, "texture")
 
     col = layout.column()
+    col.active = modifier.allow_better_hit_testing
+    col.prop(modifier, "hit_testing")
+
+    col = layout.column()
     col.active = modifier.has_gui_proc
     col.prop(modifier, "proc")
     row = col.row()

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -71,6 +71,30 @@ def _gui_anim(name: str, group: GameGuiAnimationGroup, layout, context):
             col.prop(anim, "target_material")
             col.prop(anim, "target_texture")
 
+def _gui_sounds(modifier, layout, context, sounds: Dict[str, str]):
+    box = layout.box()
+    row = box.row(align=True)
+    if hasattr(modifier, "show_expanded_sounds"):
+        exicon = "TRIA_DOWN" if modifier.show_expanded_sounds else "TRIA_RIGHT"
+        row.prop(modifier, "show_expanded_sounds", text="", icon=exicon, emboss=False)
+
+    row.label("Sound Effects")
+    if not getattr(modifier, "show_expanded_sounds", True):
+        return
+
+    soundemit = modifier.id_data.plasma_modifiers.soundemit
+    col = box.column()
+    col.active = soundemit.enabled
+    for sound_attr, label_text in sounds.items():
+        sound_name = getattr(modifier, sound_attr)
+        if sound_name:
+            sound = next((i for i in soundemit.sounds if i.name == sound_name), None)
+            alert = sound is None
+        else:
+            alert = False
+
+        col.alert = alert
+        col.prop_search(modifier, sound_attr, soundemit, "sounds", text=label_text, icon="ERROR" if alert else "SPEAKER")
 
 def gui_button(modifier, layout, context):
     row = layout.row()
@@ -80,19 +104,15 @@ def gui_button(modifier, layout, context):
     _gui_anim("Mouse Click", modifier.mouse_click_anims, layout, context)
     _gui_anim("Mouse Over", modifier.mouse_over_anims, layout, context)
 
-    box = layout.box()
-    row = box.row(align=True)
-    exicon = "TRIA_DOWN" if modifier.show_expanded_sounds else "TRIA_RIGHT"
-    row.prop(modifier, "show_expanded_sounds", text="", icon=exicon, emboss=False)
-    row.label("Sound Effects")
-    if modifier.show_expanded_sounds:
-        col = box.column()
-        soundemit = modifier.id_data.plasma_modifiers.soundemit
-        col.active = soundemit.enabled
-        col.prop_search(modifier, "mouse_down_sound", soundemit, "sounds", text="Mouse Down", icon="SPEAKER")
-        col.prop_search(modifier, "mouse_up_sound", soundemit, "sounds", text="Mouse Up", icon="SPEAKER")
-        col.prop_search(modifier, "mouse_over_sound", soundemit, "sounds", text="Mouse Over", icon="SPEAKER")
-        col.prop_search(modifier, "mouse_off_sound", soundemit, "sounds", text="Mouse Off", icon="SPEAKER")
+    _gui_sounds(
+        modifier, layout, context,
+        {
+            "mouse_down_sound": "Mouse Down",
+            "mouse_up_sound": "Mouse Up",
+            "mouse_over_sound": "Mouse Over",
+            "mouse_off_sound": "Mouse Off",
+        }
+    )
 
 def gui_clickmap(modifier: PlasamGameGuiClickMapModifier, layout, context):
     sub = layout.row()

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -149,6 +149,9 @@ def gui_control(modifier, layout, context):
     row.active = col.active and modifier.proc == "console_command"
     row.prop(modifier, "console_command")
 
+def gui_dragbar(modifier: PlasmaGameGuiDragBarModifier, layout, context):
+    layout.label("Drag Bars have no settings.")
+
 def gui_dialog(modifier, layout, context):
     row = layout.row(align=True)
     row.prop(modifier, "camera_object")

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -100,6 +100,7 @@ def gui_button(modifier, layout, context):
     row = layout.row()
     row.label("Notify On:")
     row.prop(modifier, "notify_type")
+    layout.prop(modifier, "draggable")
 
     _gui_anim("Mouse Click", modifier.mouse_click_anims, layout, context)
     _gui_anim("Mouse Over", modifier.mouse_over_anims, layout, context)
@@ -185,8 +186,14 @@ def gui_control(modifier, layout, context):
     row.active = col.active and modifier.proc == "console_command"
     row.prop(modifier, "console_command")
 
-def gui_dragbar(modifier: PlasmaGameGuiDragBarModifier, layout, context):
-    layout.label("Drag Bars have no settings.")
+def gui_draggable(modifier: PlasmaGameGuiDraggableModifier, layout, context):
+    layout.prop(modifier, "drag_target")
+
+    row = layout.row()
+    row.active = modifier.drag_target == "control"
+    row.prop(modifier, "report_dragging")
+    row.prop(modifier, "hide_cursor")
+    row.prop(modifier, "snap_back")
 
 def gui_dynamic_display(modifier: PlasmaGameGuiDynamicDisplayModifier, layout, context):
     layout.alert = modifier.texture is None

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -180,6 +180,10 @@ def gui_control(modifier, layout, context):
 def gui_dragbar(modifier: PlasmaGameGuiDragBarModifier, layout, context):
     layout.label("Drag Bars have no settings.")
 
+def gui_dynamic_display(modifier: PlasmaGameGuiDynamicDisplayModifier, layout, context):
+    layout.alert = modifier.texture is None
+    layout.prop(modifier, "texture")
+
 def gui_radio_group(modifier: PlasmaGameGuiRadioGroupModifier, layout, context):
     layout.operator("object.plasma_select_radio_group", icon="RESTRICT_SELECT_OFF")
     layout.prop(modifier, "allow_no_selection")

--- a/korman/ui/modifiers/game_gui.py
+++ b/korman/ui/modifiers/game_gui.py
@@ -163,6 +163,10 @@ def gui_control(modifier, layout, context):
     col.prop(modifier, "visible")
 
     col = split.column()
+    col.active = modifier.allow_text_scaling
+    col.prop(modifier, "scale_text")
+
+    col = split.column()
     col.prop(modifier, "tag_id")
 
     col = layout.column()


### PR DESCRIPTION
Adds enough GUI controls to really do some damage.

Add:
- GUI Clickmap (`pfGUIClickMapCtrl`)
- GUI Checkbox (`pfGUICheckBoxCtrl`)
- GUI Draggable (`pfGUIDragBarCtrl`, `pfGUIDraggableMod`)
- GUI Color Scheme (`pfGUIColorScheme` - not actually a GUI control)
- GUI Text Box (`pfGUITextBoxMod`)
- GUI Radio Group (`pfGUIRadioGroupCtrl`)
- GUI DynamicDisplay (`pfGUIDynDisplayCtrl`)
- GUI Progress Control (`pfGUIProgressCtrl`)
- GUI Value Control (`pfGUIValueCtrl` - ABC)
- GUI Input Box (`pfGUIEditBoxMod`, `pfGUIMultiLineEditCtrl`)

Game GUI support is still ***ex***perimental, meaning all of these controls are subject to change without warning or concern for backwards compatibility.

After these are merged, we will only lack:
- `pfGUIKnobCtrl`
- `pfGUIListBoxMod`
- `pfGUIPopUpMenu`
- `pfGUIUpDownPairMod`

This PR will be merged soon. If anyone has any feedback, give it ASAP.