### PR TITLE
Convert RT light color to sRGB

### DIFF
--- a/korman/exporter/animation.py
+++ b/korman/exporter/animation.py
@@ -164,12 +164,12 @@ class AnimationConverter:
             self._exporter().report.warn("Cannot animate Lamp color because neither Diffuse nor Specular are enabled")
             return None
 
-        # OK Specular is easy. We just toss out the color as a point3.
+        # Specular must be converted to sRGB space (gamma correction).
         def convert_specular_animation(color):
             if lamp.use_negative:
-                return map(lambda x: x * -1.0, color)
+                return map(lambda x: -pow(x, 1 / 2.2), color)
             else:
-                return color
+                return map(lambda x: pow(x, 1 / 2.2), color)
         color_keyframes, color_bez = self._process_keyframes(color_curves, 3, lamp.color,
                                                              convert=convert_specular_animation,
                                                              start=start, end=end)
@@ -183,10 +183,11 @@ class AnimationConverter:
 
         # Hey, look, it's a third way to process FCurves. YAY!
         def convert_diffuse_animation(color, energy):
+            # Remember to convert the color to sRGB.
             if lamp.use_negative:
-                proc = lambda x: x * -1.0 * energy[0]
+                proc = lambda x: -pow(x * energy[0], 1 / 2.2)
             else:
-                proc = lambda x: x * energy[0]
+                proc = lambda x: pow(x * energy[0], 1 / 2.2)
             return map(proc, color)
         diffuse_channels = dict(color=3, energy=1)
         diffuse_defaults = dict(color=lamp.color, energy=lamp.energy)

--- a/korman/exporter/rtlight.py
+++ b/korman/exporter/rtlight.py
@@ -122,13 +122,14 @@ class LightConverter:
 
         # Light color nonsense
         # Please note that these calculations are duplicated in the AnimationConverter
+        # Also, Blender lighting is done in linear space, whereas Plasma still uses gamma space, so convert the color to sRGB.
         energy = bl_light.energy
         if bl_light.use_negative:
-            diff_color = [(0.0 - i) * energy for i in bl_light.color]
-            spec_color = [(0.0 - i) for i in bl_light.color]
+            diff_color = [(0.0 - pow(i * energy, 1 / 2.2)) for i in bl_light.color]
+            spec_color = [(0.0 - pow(i, 1 / 2.2)) for i in bl_light.color]
         else:
-            diff_color = [i * energy for i in bl_light.color]
-            spec_color = [i for i in bl_light.color]
+            diff_color = [pow(i * energy, 1 / 2.2) for i in bl_light.color]
+            spec_color = [pow(i, 1 / 2.2) for i in bl_light.color]
 
         diff_str = "({:.4f}, {:.4f}, {:.4f})".format(*diff_color)
         diff_color.append(energy)


### PR DESCRIPTION
As described on discord the other day. Realtime light color must be converted to sRGB, otherwise they will be much darker than in Blender and suffer from hue shift/oversaturation.

This is still not perfect. Maybe because Blender does all light calculation in linear space, whereas Plasma likely doesn't - or maybe there's still something else that I have missed. But at least it's much closer now.

Animated light color may still be slightly incorrect if the interpolation is done in the wrong color space. Not much that can be done without adding more keyframes.

Blender:
<img width="1480" height="923" alt="image" src="https://github.com/user-attachments/assets/df9b0f0b-fcd7-40c4-b057-c3f94c4e2101" />
Plasma with fix (notice the middle row is still not as bright as it should be):
<img width="1480" height="923" alt="image" src="https://github.com/user-attachments/assets/c964092e-84fa-4b35-92d5-a94fc5668437" />

Test file:
[LightTest.zip](https://github.com/user-attachments/files/22321286/LightTest.zip)

Ages exported with previous versions of Korman will likely see their realtime lighting be brighter, and manual adjustment will be necessary.