### PR TITLE
Add link event trigger node.

### DIFF
--- a/korman/nodes/node_conditions.py
+++ b/korman/nodes/node_conditions.py
@@ -404,6 +404,106 @@ class PlasmaFacingTargetSocket(PlasmaNodeSocketBase, bpy.types.NodeSocket):
         return (not self.is_linked and not self.is_output)
 
 
+class PlasmaLinkEventNode(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "CONDITIONS"
+    bl_idname = "PlasmaLinkEventNode"
+    bl_label = "Link Event"
+    bl_width_default = 320
+
+    trigger_for = EnumProperty(
+        name="Trigger For",
+        items=[
+            ("Me", "Local Player", "Trigger only for the local player"),
+            ("NPCs", "NPCs", "Trigger for NPCs (eg quabs)"),
+            ("Player Avatars", "Player Avatars", "Trigger for player controlled avatars"),
+            ("Everyone", "Everyone", "Trigger for all avatars"),
+        ],
+        default="Me",
+        options=set()
+    )
+    trigger_on = EnumProperty(
+        name="Trigger On",
+        items=[
+            ("Spawn", "Avatar Spawns", "Trigger when an avatar spawns"),
+            ("Link", "Avatar Links", "Trigger when an avatar links"),
+        ],
+        default="Spawn",
+        options=set()
+    )
+    trigger_direction = EnumProperty(
+        name="Trigger Direction",
+        items=[
+            ("In", "In", "Trigger when the avatar links/spawns into the Age"),
+            ("Out", "Out", "Trigger when the avatar links/spawns out of the Age"),
+        ],
+        default="In",
+        options=set()
+    )
+    trigger_at = EnumProperty(
+        name="Trigger At",
+        items=[
+            ("Start", "Event Start", "Trigger when the interesting event begins"),
+            ("End", "Event End", "Trigger when the interesting event ends"),
+        ],
+        default="Start",
+        options=set()
+    )
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "satisfies": {
+            "text": "Satisfies",
+            "type": "PlasmaConditionSocket",
+            "valid_link_sockets": {"PlasmaConditionSocket", "PlasmaPythonFileNodeSocket"},
+        },
+    }
+
+    def draw_buttons(self, context, layout):
+        combo = (self.trigger_for, self.trigger_on, self.trigger_direction)
+
+        layout.alert = combo == ("Me", "Spawn", "Out")
+        layout.prop(self, "trigger_for")
+        layout.alert = False
+
+        layout.prop(self, "trigger_on")
+        layout.prop(self, "trigger_direction")
+        layout.prop(self, "trigger_at")
+
+    def get_key(self, exporter: Exporter, so) -> plKey[plLogicModifier]:
+        return self._find_create_key(plLogicModifier, exporter, so=so)
+
+    def export(self, exporter: Exporter, bo, so) -> None:
+        combo = (self.trigger_for, self.trigger_on, self.trigger_direction)
+        if combo == ("Me", "Spawn", "Out"):
+            self.raise_error("Cannot trigger when the local player spawns out")
+
+        # There is no class in the engine that will fire when someone links in. There are messages,
+        # though, and they all get to Python in one way or another. So, to fire an event on link
+        # or spawn, we're going to use a helper script xLinkEventTrigger. It will send a notification
+        # to a kMultiTrigger LogicMod with a plActivatorActivatorConditionalObject. LMs forward
+        # all plNotifyMsgs to their conditions, and plAACO activates on any state==1.0 plNotifyMsg,
+        # assuming that the LogicMod is not already marked as triggered and all of the other conditions
+        # say that they're in a valid state. Once that LogicMod fires, anything we want can be fired
+        # off, like other PFMs or Responders. A potential optimization here is to avoid creation
+        # of the plAACO/plLM thunk if we only have responders attached.
+        activator = self._find_create_object(plActivatorActivatorConditionalObject, exporter, so=so)
+        logicmod = self._find_create_object(plLogicModifier, exporter, so=so)
+        logicmod.addCondition(activator.key)
+        logicmod.notify = self.generate_notify_msg(exporter, so, "satisfies")
+        logicmod.setLogicFlag(plLogicModifier.kMultiTrigger, True)
+        logicmod.setLogicFlag(plLogicModifier.kLocalElement, True)
+
+        pfm = self._find_create_object(plPythonFileMod, exporter, so=so)
+        pfm.filename = "xLinkEventTrigger"
+        self._add_py_parameter(pfm, 1, plPythonParameter.kResponder, logicmod.key)
+        self._add_py_parameter(pfm, 100, plPythonParameter.kString, f"{self.trigger_on} {self.trigger_direction}")
+        self._add_py_parameter(pfm, 101, plPythonParameter.kString, self.trigger_for)
+        self._add_py_parameter(pfm, 102, plPythonParameter.kString, self.trigger_at)
+
+    @property
+    def export_once(self):
+        return True
+
+
 class PlasmaVolumeReportNode(PlasmaNodeBase, bpy.types.Node):
     bl_category = "CONDITIONS"
     bl_idname = "PlasmaVolumeReportNode"

--- a/korman/nodes/node_conditions.py
+++ b/korman/nodes/node_conditions.py
@@ -453,7 +453,7 @@ class PlasmaLinkEventNode(PlasmaNodeBase, bpy.types.Node):
         "satisfies": {
             "text": "Satisfies",
             "type": "PlasmaConditionSocket",
-            "valid_link_sockets": {"PlasmaConditionSocket", "PlasmaPythonFileNodeSocket"},
+            "valid_link_nodes": {"PlasmaResponderNode", "PlasmaBasicResponderNode"},
         },
     }
 
@@ -468,9 +468,6 @@ class PlasmaLinkEventNode(PlasmaNodeBase, bpy.types.Node):
         layout.prop(self, "trigger_direction")
         layout.prop(self, "trigger_at")
 
-    def get_key(self, exporter: Exporter, so) -> plKey[plLogicModifier]:
-        return self._find_create_key(plLogicModifier, exporter, so=so)
-
     def export(self, exporter: Exporter, bo, so) -> None:
         combo = (self.trigger_for, self.trigger_on, self.trigger_direction)
         if combo == ("Me", "Spawn", "Out"):
@@ -478,23 +475,17 @@ class PlasmaLinkEventNode(PlasmaNodeBase, bpy.types.Node):
 
         # There is no class in the engine that will fire when someone links in. There are messages,
         # though, and they all get to Python in one way or another. So, to fire an event on link
-        # or spawn, we're going to use a helper script xLinkEventTrigger. It will send a notification
-        # to a kMultiTrigger LogicMod with a plActivatorActivatorConditionalObject. LMs forward
-        # all plNotifyMsgs to their conditions, and plAACO activates on any state==1.0 plNotifyMsg,
-        # assuming that the LogicMod is not already marked as triggered and all of the other conditions
-        # say that they're in a valid state. Once that LogicMod fires, anything we want can be fired
-        # off, like other PFMs or Responders. A potential optimization here is to avoid creation
-        # of the plAACO/plLM thunk if we only have responders attached.
-        activator = self._find_create_object(plActivatorActivatorConditionalObject, exporter, so=so)
-        logicmod = self._find_create_object(plLogicModifier, exporter, so=so)
-        logicmod.addCondition(activator.key)
-        logicmod.notify = self.generate_notify_msg(exporter, so, "satisfies")
-        logicmod.setLogicFlag(plLogicModifier.kMultiTrigger, True)
-        logicmod.setLogicFlag(plLogicModifier.kLocalElement, True)
-
+        # or spawn, we're going to use a helper script xLinkEventTrigger. I originally wrote this
+        # to trigger a plLogicModifier with a plActivatorActivatorConditionalObject attached to
+        # forward the trigger to another arbitrary plLogicMod. Unfortunately, plAACO does not
+        # forward notification details to the downstream LogicMod, so if you wanted to run a
+        # responder that targets an avatar somewhere in that tree, you're sunk. I could modify
+        # the engine, but that becomes non-trivial due to TPotS being closed source. So, I've
+        # changed this to only accept Responders.
         pfm = self._find_create_object(plPythonFileMod, exporter, so=so)
         pfm.filename = "xLinkEventTrigger"
-        self._add_py_parameter(pfm, 1, plPythonParameter.kResponder, logicmod.key)
+        for i in self.find_outputs("satisfies"):
+            self._add_py_parameter(pfm, 1, plPythonParameter.kResponder, i.get_key(exporter, so))
         self._add_py_parameter(pfm, 100, plPythonParameter.kString, f"{self.trigger_on} {self.trigger_direction}")
         self._add_py_parameter(pfm, 101, plPythonParameter.kString, self.trigger_for)
         self._add_py_parameter(pfm, 102, plPythonParameter.kString, self.trigger_at)

--- a/korman/nodes/node_core.py
+++ b/korman/nodes/node_core.py
@@ -28,6 +28,13 @@ if TYPE_CHECKING:
     from ..exporter import Exporter
 
 class PlasmaNodeBase:
+    def _add_py_parameter(self, pfm: plPythonFileMod, id: int, param_type: int, value) -> None:
+        param = plPythonParameter()
+        param.id = id
+        param.valueType = param_type
+        param.value = value
+        pfm.addParameter(param)
+
     def generate_notify_msg(self, exporter: Exporter, so: plSceneObject, socket_id: str, idname: Optional[str] = None) -> plNotifyMsg:
         notify = plNotifyMsg()
         notify.BCastFlags = (plMessage.kNetPropagate | plMessage.kLocalPropagate)

--- a/korman/nodes/node_python.py
+++ b/korman/nodes/node_python.py
@@ -329,14 +329,15 @@ class PlasmaPythonFileNode(PlasmaVersionedNode, bpy.types.Node):
             if isinstance(value, str) or not isinstance(value, Iterable):
                 value = (value,)
             for i in value:
-                param = plPythonParameter()
-                param.id = socket.attribute_id
-                param.valueType = _attrib2param[socket.attribute_type]
-                param.value = i
+                self._add_py_parameter(
+                    pfm,
+                    socket.attribute_id,
+                    _attrib2param[socket.attribute_type],
+                    i
+                )
 
                 if not socket.is_simple_value:
                     self._export_key_attrib(exporter, bo, so, pfm, i, socket)
-                pfm.addParameter(param)
 
     def _export_ancillary_sceneobject(self, exporter: Exporter, bo, so: plSceneObject) -> None:
         # Danger: Special case evil ahoy...


### PR DESCRIPTION
This is a higher level use case of the xLinkEventTrigger.py file introduced in H-uru/Plasma#1821. RIght now, this is just an example. I still have some iteration to do here, and I would like to add some more high level logic nodes to improve the workflow where Python has to get involved.

Python File nodes are tricky because the attributes are inputs to the script but function logically as outputs. For example, responders appear as an input to a Python file node, but Python file nodes can trigger responders. The inverse is also true. In the case of `xLinkEventTrigger.py`, we see the same thing - normally an activator is an input/trigger for a Python file node, but, in this case, the Python script is triggering the activator so that the responder or other things connected under "satisfies" can proceed.