### PR TITLE
Improve Responder Workflow

### DIFF
--- a/korman/helpers.py
+++ b/korman/helpers.py
@@ -15,7 +15,9 @@
 
 import bmesh
 import bpy
+
 from contextlib import contextmanager
+import functools
 import math
 from typing import *
 from uuid import uuid4
@@ -59,6 +61,15 @@ class GoodNeighbor:
         for (cls, attr), value in self._tracking.items():
             setattr(cls, attr, value)
 
+def run_once(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        if not wrapper.has_run:
+            wrapper.has_run = True
+            return f(*args, **kwargs)
+
+    wrapper.has_run = False
+    return wrapper
 
 @contextmanager
 def TemporaryCollectionItem(collection):

--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -53,6 +53,11 @@ class PlasmaMessageNode(PlasmaNodeBase):
         """This message does not have callbacks that can be waited on by a Responder"""
         return False
 
+    @property
+    def is_notify(self) -> bool:
+        """Does this message notify the triggerer?"""
+        return False
+
 
 class PlasmaMessageWithCallbacksNode(PlasmaMessageNode):
     output_sockets: dict[str, dict[str, str]] = {
@@ -582,6 +587,34 @@ class PlasmaLinkToAgeMsg(PlasmaMessageNode, bpy.types.Node):
 
         layout.prop(self, "spawn_title")
         layout.prop(self, "spawn_point")
+
+
+class PlasmaNotifyTriggererMsg(PlasmaMessageNode, bpy.types.Node):
+    bl_category = "MSG"
+    bl_idname = "PlasmaNotifyTriggererMsg"
+    bl_label = "Notify Triggerer"
+
+    event_id = IntProperty(
+        name="Event ID",
+        description="Notification Event ID to send to the triggerer",
+        default=1,
+        options=set()
+    )
+
+    def convert_message(self, exporter: Exporter, so: plSceneObject) -> plMessage:
+        event = proCallbackEventData()
+        event.callbackEventType = self.event_id
+        msg = plNotifyMsg()
+        msg.state = 1.0
+        msg.addEvent(event)
+        return msg
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "event_id")
+
+    @property
+    def is_notify(self) -> bool:
+        return True
 
 
 class PlasmaOneShotMsgNode(idprops.IDPropObjectMixin, PlasmaMessageWithCallbacksNode, bpy.types.Node):

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -129,7 +129,7 @@ class PlasmaBasicResponderNode(PlasmaVersionedNode, PlasmaResponderNodeBase, bpy
 
     output_sockets: dict[str, dict[str, Any]] = {
         "keyref": {
-            "text": "References",
+            "text": "Host Script",
             "type": "PlasmaPythonReferenceNodeSocket",
             "valid_link_nodes": {"PlasmaPythonFileNode"},
         },
@@ -180,17 +180,27 @@ class PlasmaResponderNode(PlasmaVersionedNode, PlasmaResponderNodeBase, bpy.type
     bl_label = "Responder"
     bl_width_default = 145
 
-    detect_trigger = BoolProperty(name="Detect Trigger",
-                                  description="When notified, trigger the Responder",
-                                  default=True)
-    detect_untrigger = BoolProperty(name="Detect UnTrigger",
-                                    description="When notified, untrigger the Responder",
-                                    default=False)
-    no_ff_sounds = BoolProperty(name="Don't F-Fwd Sounds",
-                                description="When fast-forwarding, play sound effects",
-                                default=False)
-    default_state = IntProperty(name="Default State Index",
-                                options=set())
+    detect_trigger = BoolProperty(
+        name="Detect Trigger",
+        description="When a trigger notification (state == 1.0) is received, run the Responder",
+        default=True,
+        options=set()
+        )
+    detect_untrigger = BoolProperty(
+        name="Detect UnTrigger",
+        description="When an untrigger notification (state == 0.0) is received, run the Responder",
+        options=set()
+    )
+    no_ff_sounds = BoolProperty(
+        name="Don't F-Fwd Sounds",
+        description="When fast-forwarding, play sound effects",
+        default=False,
+        options=set()
+    )
+    default_state = IntProperty(
+        name="Default State Index",
+        options=set()
+    )
 
     input_sockets: dict[str, dict[str, Any]] = {
         "condition": {
@@ -202,7 +212,7 @@ class PlasmaResponderNode(PlasmaVersionedNode, PlasmaResponderNodeBase, bpy.type
 
     output_sockets: dict[str, dict[str, Any]] = {
         "keyref": {
-            "text": "References",
+            "text": "Host Script",
             "type": "PlasmaPythonReferenceNodeSocket",
             "valid_link_nodes": {"PlasmaPythonFileNode"},
         },

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -498,14 +498,17 @@ class PlasmaResponderStateNode(PlasmaVersionedNode, bpy.types.Node):
         if msgNode.has_callbacks:
             commandMgr.add_waitable_node(msgNode)
             if msgNode.has_linked_callbacks:
-                childWaitOn = commandMgr.add_wait(idx)
-                msgNode.convert_callback_message(exporter, so, msg, responder.key, childWaitOn)
-        else:
-            childWaitOn = waitOn
+                # Only one "branch" of a Responder is allowed to have callbacks. That is to say
+                # that if we have a message that sends two other messages on completion, only one
+                # of those two messages can have messages sent after it completes. Plasma doesn't
+                # have a concept of sending a batch of messages and waiting on them. It's a serial
+                # send-wait, send-wait. So, overriding the waitOn we were initially given is fine.
+                waitOn = commandMgr.add_wait(idx)
+                msgNode.convert_callback_message(exporter, so, msg, responder.key, waitOn)
 
         # Export any linked callback messages
         for i in self._get_child_messages(msgNode):
-            self._generate_command(exporter, so, responder, commandMgr, i, childWaitOn)
+            self._generate_command(exporter, so, responder, commandMgr, i, waitOn)
 
     def _get_child_messages(self, node=None):
         """Returns a list of the message nodes sent by `node`. The list is sorted such that any

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -25,6 +25,41 @@ import uuid
 from .node_core import *
 from .node_deprecated import PlasmaVersionedNode
 
+class _ResponderStateMgr:
+    def __init__(self, respNode: PlasmaNodeBase, respMod: plResponderModifier):
+        self.states = []
+        self.parent = respNode
+        self.responder = respMod
+        self.has_pfm = respNode.find_output("keyref") is not None
+
+    def convert_states(self, exporter, so):
+        # This could implicitly export more states...
+        i = 0
+        while i < len(self.states):
+            node, state = self.states[i]
+            node.convert_state(exporter, so, state, i, self)
+            i += 1
+
+        if not self.states:
+            self.parent.raise_error("No states converted by Responder node")
+
+        resp = self.responder
+        resp.clearStates()
+        for node, state in self.states:
+            resp.addState(state)
+
+    def get_state(self, node):
+        for idx, (theNode, theState) in enumerate(self.states):
+            if theNode == node:
+                return (idx, theState)
+        state = plResponderModifier_State()
+        self.states.append((node, state))
+        return (len(self.states) - 1, state)
+
+    def register_state(self, node):
+        self.states.append((node, plResponderModifier_State()))
+
+
 class PlasmaResponderNode(PlasmaVersionedNode, bpy.types.Node):
     bl_category = "LOGIC"
     bl_idname = "PlasmaResponderNode"
@@ -115,42 +150,8 @@ class PlasmaResponderNode(PlasmaVersionedNode, bpy.types.Node):
             responder.flags |= plResponderModifier.kSkipFFSound
         responder.curState = self.default_state
 
-        class ResponderStateMgr:
-            def __init__(self, respNode, respMod):
-                self.states = []
-                self.parent = respNode
-                self.responder = respMod
-                self.has_pfm = respNode.find_output("keyref") is not None
-
-            def convert_states(self, exporter, so):
-                # This could implicitly export more states...
-                i = 0
-                while i < len(self.states):
-                    node, state = self.states[i]
-                    node.convert_state(exporter, so, state, i, self)
-                    i += 1
-
-                if not self.states:
-                    self.parent.raise_error("No states converted by Responder node")
-
-                resp = self.responder
-                resp.clearStates()
-                for node, state in self.states:
-                    resp.addState(state)
-
-            def get_state(self, node):
-                for idx, (theNode, theState) in enumerate(self.states):
-                    if theNode == node:
-                        return (idx, theState)
-                state = plResponderModifier_State()
-                self.states.append((node, state))
-                return (len(self.states) - 1, state)
-
-            def register_state(self, node):
-                self.states.append((node, plResponderModifier_State()))
-
         # Convert the Responder states
-        stateMgr = ResponderStateMgr(self, responder)
+        stateMgr = _ResponderStateMgr(self, responder)
         for stateNode in self.find_outputs("state_refs", "PlasmaResponderStateNode"):
             stateMgr.register_state(stateNode)
         stateMgr.convert_states(exporter, so)

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -21,6 +21,7 @@ from typing import *
 import inspect
 from PyHSPlasma import *
 
+from ..helpers import TemporaryObject
 from .node_core import *
 from .node_deprecated import PlasmaVersionedNode
 
@@ -112,6 +113,66 @@ class PlasmaResponderNodeBase(PlasmaNodeBase):
             (i.to_socket.attribute_type == "ptAttribNamedResponder"
              for i in self.find_output_socket("keyref").links)
         )
+
+
+class PlasmaBasicResponderNode(PlasmaVersionedNode, PlasmaResponderNodeBase, bpy.types.Node):
+    bl_category = "LOGIC"
+    bl_idname = "PlasmaBasicResponderNode"
+    bl_label = "Basic Responder"
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "condition": {
+            "text": "Condition",
+            "type": "PlasmaConditionSocket",
+            "spawn_empty": True,
+        },
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "keyref": {
+            "text": "References",
+            "type": "PlasmaPythonReferenceNodeSocket",
+            "valid_link_nodes": {"PlasmaPythonFileNode"},
+        },
+        "msgs": {
+            "text": "Send Message",
+            "type": "PlasmaMessageSocket",
+            "valid_link_sockets": "PlasmaMessageSocket",
+        },
+        # This socket only exists to make the code safe. It will never be seen by the user.
+        "state_refs": {
+            "text": "State",
+            "type": "PlasmaRespStateRefSocket",
+            "valid_link_nodes": "PlasmaResponderStateNode",
+            "valid_link_sockets": "PlasmaRespStateRefSocket",
+            "hidden": True,
+            "link_limit": 1,
+        },
+    }
+
+    def export(self, exporter, bo, so):
+        # This node exists to simplify the creation of Responders even further. The old Responder
+        # node is very close to what Plasma does under the hood and what PlasmaMax exposes. I
+        # removed the "command" node in version 2 of that node, but, really, most responders just
+        # need to send some messages when they are triggered with a notify of state==1.0. That's
+        # what our goal is. Not worrying about Responder states, switch to, when to fire, etc.
+        responder = self.create_responder(exporter, bo, so)
+        responder.flags |= plResponderModifier.kDetectTrigger
+
+        # This is a bit of a hack, but it allows us to reuse the existing well-tested Responder
+        # export code and not have to write a new code path. We're going to sneakily create a
+        # Responder State node for our only state and link our messages to it. Then link the state
+        # node to ourselves, just in case the export code ever cares. Then, we can just fire the
+        # old export code.
+        nodes = self.id_data.nodes
+        with TemporaryObject(nodes.new("PlasmaResponderStateNode"), nodes.remove) as state_node:
+            self.link_output(state_node, "state_refs", "resp")
+            for i in self.find_outputs("msgs"):
+                state_node.link_output(i, "msgs", "sender")
+
+            stateMgr = _ResponderStateMgr(self, responder)
+            stateMgr.register_state(state_node)
+            stateMgr.convert_states(exporter, so)
 
 
 class PlasmaResponderNode(PlasmaVersionedNode, PlasmaResponderNodeBase, bpy.types.Node):
@@ -255,7 +316,6 @@ class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
         "resp": {
             "text": "Responder",
             "type": "PlasmaRespStateRefSocket",
-            "valid_link_nodes": "PlasmaResponderNode",
             "valid_link_sockets": "PlasmaRespStateRefSocket",
         },
     }

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -20,19 +20,23 @@ from bpy.props import *
 from typing import *
 import inspect
 from PyHSPlasma import *
-import uuid
 
 from .node_core import *
 from .node_deprecated import PlasmaVersionedNode
 
+class _ResponderState(NamedTuple):
+    node: PlasmaResponderStateNode
+    state: plResponderModifier_State
+
+
 class _ResponderStateMgr:
     def __init__(self, respNode: PlasmaNodeBase, respMod: plResponderModifier):
-        self.states = []
+        self.states: List[_ResponderState] = []
         self.parent = respNode
         self.responder = respMod
         self.has_pfm = respNode.find_output("keyref") is not None
 
-    def convert_states(self, exporter, so):
+    def convert_states(self, exporter: Exporter, so: plSceneObject):
         # This could implicitly export more states...
         i = 0
         while i < len(self.states):
@@ -48,16 +52,16 @@ class _ResponderStateMgr:
         for node, state in self.states:
             resp.addState(state)
 
-    def get_state(self, node):
+    def get_state(self, node) -> Tuple[int, plResponderModifier_State]:
         for idx, (theNode, theState) in enumerate(self.states):
             if theNode == node:
                 return (idx, theState)
         state = plResponderModifier_State()
-        self.states.append((node, state))
+        self.states.append(_ResponderState(node, state))
         return (len(self.states) - 1, state)
 
     def register_state(self, node):
-        self.states.append((node, plResponderModifier_State()))
+        self.states.append(_ResponderState(node, plResponderModifier_State()))
 
 
 class PlasmaResponderNode(PlasmaVersionedNode, bpy.types.Node):
@@ -270,7 +274,14 @@ class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
         layout.active = self.find_input("resp") is not None
         layout.prop(self, "default_state")
 
-    def convert_state(self, exporter, so, state, idx, stateMgr):
+    def convert_state(
+        self,
+        exporter: Exporter,
+        so: plSceneObject,
+        state: plResponderModifier_State,
+        idx: int,
+        stateMgr: _ResponderStateMgr
+    ):
         # Where do we go from heah?
         toStateNode = self.find_output("gotostate", "PlasmaResponderStateNode")
         if toStateNode is None:

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -64,14 +64,61 @@ class _ResponderStateMgr:
         self.states.append(_ResponderState(node, plResponderModifier_State()))
 
 
-class PlasmaResponderNode(PlasmaVersionedNode, bpy.types.Node):
+class PlasmaResponderNodeBase(PlasmaNodeBase):
+    # These are the Python attributes we can fill in
+    pl_attrib = {"ptAttribResponder", "ptAttribResponderList", "ptAttribNamedResponder"}
+
+    def create_responder(
+        self,
+        exporter: Exporter,
+        bo: bpy.types.Object,
+        so: plSceneObject
+    ) -> plResponderModifier:
+        responder = self.get_key(exporter, so).object
+
+        # Ensure there is not already a Responder that matches this name in the PRP
+        # if we are a named responder. This will be a very rare error - the responder must
+        # be linked to a ptAttribNamedResponder for this to trigger.
+        if self.is_named_responder and responder.states:
+            self.raise_error(f"A Responder named '{self.name}' has already been exported to this page.")
+        if not bo.plasma_net.manual_sdl:
+            responder.setExclude("Responder")
+
+        return responder
+
+    def get_key(self, exporter, so) -> plKey[plResponderModifier]:
+        return self._find_create_key(plResponderModifier, exporter, so=so)
+
+    def get_key_name(self, single, suffix=None, bl=None, so=None) -> str:
+        # If we're connected to a ptAttribNamedResponder, then we need to use our exact
+        # name in the node tree. This introduces potential collisions, so named responders
+        # are opt-in behavior.
+        if self.is_named_responder:
+            return self.name
+        else:
+            return super().get_key_name(single, suffix, bl, so)
+
+    @property
+    def export_once(self):
+        # What exactly is a reused responder? All the messages are directed, after all...
+        return True
+
+    @property
+    def is_named_responder(self) -> bool:
+        # Check to see if any of the Python attributes that we're linked to are ptAttribNamedResponder.
+        # We'll need to navigate from our keyref output socket (PFM socket) to the PFM attribute
+        # socket and test the `attribute_type` for all links.
+        return any(
+            (i.to_socket.attribute_type == "ptAttribNamedResponder"
+             for i in self.find_output_socket("keyref").links)
+        )
+
+
+class PlasmaResponderNode(PlasmaVersionedNode, PlasmaResponderNodeBase, bpy.types.Node):
     bl_category = "LOGIC"
     bl_idname = "PlasmaResponderNode"
     bl_label = "Responder"
     bl_width_default = 145
-
-    # These are the Python attributes we can fill in
-    pl_attrib = {"ptAttribResponder", "ptAttribResponderList", "ptAttribNamedResponder"}
 
     detect_trigger = BoolProperty(name="Detect Trigger",
                                   description="When notified, trigger the Responder",
@@ -123,29 +170,8 @@ class PlasmaResponderNode(PlasmaVersionedNode, bpy.types.Node):
         layout.prop(self, "detect_untrigger")
         layout.prop(self, "no_ff_sounds")
 
-    def get_key(self, exporter, so) -> plKey[plResponderModifier]:
-        return self._find_create_key(plResponderModifier, exporter, so=so)
-
-    def get_key_name(self, single, suffix=None, bl=None, so=None) -> str:
-        # If we're connected to a ptAttribNamedResponder, then we need to use our exact
-        # name in the node tree. This introduces potential collisions, so named responders
-        # are opt-in behavior.
-        if self.is_named_responder:
-            return self.name
-        else:
-            return super().get_key_name(single, suffix, bl, so)
-
     def export(self, exporter, bo, so):
-        # Ensure there is not already a Responder that matches this name in the PRP
-        # if we are a named responder. This will be a very rare error - the responder must
-        # be linked to a ptAttribNamedResponder for this to trigger.
-        if self.is_named_responder and self._find_key(plResponderModifier, exporter, so=so):
-            self.raise_error(f"A Responder named '{self.name}' has already been exported to this page.")
-
-        responder = self.get_key(exporter, so).object
-        if not bo.plasma_net.manual_sdl:
-            responder.setExclude("Responder")
-
+        responder = self.create_responder(exporter, bo, so)
         if self.detect_trigger:
             responder.flags |= plResponderModifier.kDetectTrigger
         if self.detect_untrigger:
@@ -159,21 +185,6 @@ class PlasmaResponderNode(PlasmaVersionedNode, bpy.types.Node):
         for stateNode in self.find_outputs("state_refs", "PlasmaResponderStateNode"):
             stateMgr.register_state(stateNode)
         stateMgr.convert_states(exporter, so)
-
-    @property
-    def export_once(self):
-        # What exactly is a reused responder? All the messages are directed, after all...
-        return True
-
-    @property
-    def is_named_responder(self) -> bool:
-        # Check to see if any of the Python attributes that we're linked to are ptAttribNamedResponder.
-        # We'll need to navigate from our keyref output socket (PFM socket) to the PFM attribute
-        # socket and test the `attribute_type` for all links.
-        return any(
-            (i.to_socket.attribute_type == "ptAttribNamedResponder"
-             for i in self.find_output_socket("keyref").links)
-        )
 
     @property
     def latest_version(self):

--- a/korman/nodes/node_responder.py
+++ b/korman/nodes/node_responder.py
@@ -21,7 +21,7 @@ from typing import *
 import inspect
 from PyHSPlasma import *
 
-from ..helpers import TemporaryObject
+from ..helpers import run_once, TemporaryObject
 from .node_core import *
 from .node_deprecated import PlasmaVersionedNode
 
@@ -35,7 +35,6 @@ class _ResponderStateMgr:
         self.states: List[_ResponderState] = []
         self.parent = respNode
         self.responder = respMod
-        self.has_pfm = respNode.find_output("keyref") is not None
 
     def convert_states(self, exporter: Exporter, so: plSceneObject):
         # This could implicitly export more states...
@@ -275,7 +274,7 @@ class PlasmaResponderNode(PlasmaVersionedNode, PlasmaResponderNodeBase, bpy.type
             self.version = 2
 
 
-class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
+class PlasmaResponderStateNode(PlasmaVersionedNode, bpy.types.Node):
     bl_category = "LOGIC"
     bl_idname = "PlasmaResponderStateNode"
     bl_label = "Responder State"
@@ -306,6 +305,21 @@ class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
                                  get=_get_default_state,
                                  set=_set_default_state,
                                  options=set())
+
+    export_auto_notify_value = BoolProperty(options={"HIDDEN"})
+    def _get_auto_notify(self):
+        if not self.allow_auto_notify:
+            return False
+        return self.export_auto_notify_value
+    def _set_auto_notify(self, value: bool) -> None:
+        self.export_auto_notify_value = value
+    export_auto_notify = BoolProperty(
+        name="Auto Notify",
+        description="When this state completes, automatically send a notification to whoever triggered the Responder",
+        get=_get_auto_notify,
+        set=_set_auto_notify,
+        options=set()
+    )
 
     input_sockets: dict[str, Any] = {
         "condition": {
@@ -341,9 +355,24 @@ class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
         },
     }
 
+    @property
+    def allow_auto_notify(self):
+        resp_node = self.find_input("resp")
+        if resp_node is None:
+            return False
+        if resp_node.find_output("keyref") is None:
+            return False
+        if self.has_notify:
+            return False
+        return True
+
     def draw_buttons(self, context, layout):
-        layout.active = self.find_input("resp") is not None
-        layout.prop(self, "default_state")
+        row = layout.row()
+        row.active = self.find_input("resp") is not None
+        row.prop(self, "default_state")
+        row = layout.row()
+        row.active = self.allow_auto_notify
+        row.prop(self, "export_auto_notify")
 
     def convert_state(
         self,
@@ -362,11 +391,18 @@ class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
             state.switchToState = toIdx
 
         class CommandMgr:
-            def __init__(self, respMod):
+            def __init__(self, respMod: plResponderModifier, state: plResponderModifier_State):
                 self.commands = []
                 self.responder = respMod
+                self._state = state
                 self.waits = {}
                 self.waitable_nodes = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, type, value, traceback):
+                self.save()
 
             def add_command(self, node, waitOn):
                 cmd = type("ResponderCommand", (), {"msg": None, "waitOn": waitOn})
@@ -394,41 +430,49 @@ class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
                     node.convert_callback_message(exporter, so, cmd[1].msg, self.responder.key, wait)
                 return wait
 
-            def save(self, state):
+            @run_once
+            def save(self):
                 for node, cmd in self.commands:
                     # Amusing, PyHSPlasma doesn't actually want a plResponderModifier_Cmd
                     # Meh, I'll let this one slide.
-                    state.addCommand(cmd.msg, cmd.waitOn)
-                state.numCallbacks = len(self.waits)
-                state.waitToCmd = self.waits
+                    self._state.addCommand(cmd.msg, cmd.waitOn)
+                self._state.numCallbacks = len(self.waits)
+                self._state.waitToCmd = self.waits
 
         # Convert the commands
-        commands = CommandMgr(stateMgr.responder)
-        for i in self._get_child_messages():
-            # slight optimization--commands attached to states can't wait on other commands
-            # namely because it's impossible to wait on a command that doesn't exist...
-            self._generate_command(exporter, so, stateMgr.responder, commands, i)
+        with CommandMgr(stateMgr.responder, state) as commands:
+            for i in self._get_child_messages():
+                # slight optimization--commands attached to states can't wait on other commands
+                # namely because it's impossible to wait on a command that doesn't exist...
+                self._generate_command(exporter, so, stateMgr.responder, commands, i)
 
-        # The last waitable message node may or may not have child nodes attached to it.
-        # Imaging a responder that sends only one animation command message, for example.
-        # That means a wait will not be set up for that command due to no child linkage.
-        # However, the PFM notification below expects a wait for stuff like that.
-        if stateMgr.has_pfm:
-            lastWait = commands.ensure_last_wait(exporter, so)
+            # Korman would originally notify any attached PFM by default at the end of the Responder
+            # state. In PlasmaMax, the "Notify Triggerer" is a manual option, and most Responders
+            # actually don't do this. So, in the interest of removing cruft and better exposing
+            # our behavior, only do this if the old behavior is explicitly requested.
+            if self.export_auto_notify:
+                # The last waitable message node may or may not have child nodes attached to it.
+                # Imaging a responder that sends only one animation command message, for example.
+                # That means a wait will not be set up for that command due to no child linkage.
+                # However, the PFM notification below expects a wait for stuff like that.
+                lastWait = commands.ensure_last_wait(exporter, so)
 
-        # This commits the responder commands to the responder. Needs to happen before we
-        # add the PFM notification directly to the responder.
-        commands.save(state)
+                # This commits the responder commands to the responder. Needs to happen before we
+                # add the PFM notification directly to the responder. This would normally happen
+                # when the context manager exits, but we're going to force it to happen now,
+                # and only now.
+                commands.save()
 
-        # If the responder is linked to a PythonFile node, we need to automatically generate
-        # the callback message command node...
-        if stateMgr.has_pfm:
-            pfmNotify = plNotifyMsg()
-            pfmNotify.BCastFlags |= plMessage.kLocalPropagate
-            pfmNotify.sender = stateMgr.responder.key
-            pfmNotify.state = 1.0
-            pfmNotify.addEvent(proCallbackEventData())
-            state.addCommand(pfmNotify, lastWait)
+                # Manually insert the callback event notify message command. It would have been nice
+                # to spawn the node to allow code deduplication, but the structure of the old code
+                # means this pattern is nicer.
+                cbEvent = proCallbackEventData()
+                cbEvent.callbackEventType = 1
+                pfmNotify = plNotifyMsg()
+                pfmNotify.sender = stateMgr.responder.key
+                pfmNotify.state = 1.0
+                pfmNotify.addEvent(cbEvent)
+                state.addCommand(pfmNotify, lastWait)
 
     def _generate_command(self, exporter, so, responder, commandMgr, msgNode, waitOn=-1):
         def prepare_message(exporter, so, responder, commandMgr, waitOn, msg):
@@ -470,6 +514,30 @@ class PlasmaResponderStateNode(PlasmaNodeBase, bpy.types.Node):
         if node is None:
             node = self
         return sorted(node.find_outputs("msgs"), key=lambda x: bool(x.has_callbacks and x.has_linked_callbacks))
+
+    @property
+    def has_notify(self):
+        def check_for_notify(node):
+            for i in node.find_outputs("msgs"):
+                yield i.is_notify
+                yield from check_for_notify(i)
+        return any(check_for_notify(self))
+
+    @property
+    def latest_version(self):
+        return 2
+
+    def upgrade(self):
+        # In Version 2 of the node, the automatic notification of attached PFMs has been turned off
+        # by default. To ensure esoteric node trees don't suddenly break, any nodes that have
+        # attached PFMs will default to this functionality being ON after upgrading. New nodes
+        # will default to OFF.
+        if self.version == 1:
+            # Just directly set the value if auto notification is allowed. Otherwise, leave it
+            # at the default value.
+            if self.allow_auto_notify:
+                self.export_auto_notify_value = True
+            self.version = 2
 
 
 class PlasmaRespStateSocket(PlasmaNodeSocketBase, bpy.types.NodeSocket):


### PR DESCRIPTION
This PR improves the Responder node workflow by adding a new node - the Basic Responder. The basic Responder allows artists to more simply graph trivial, single state Responders with fewer nodes. The Basic Responder node accepts a condition, a PFM reference, and a list of messages to send.

While I was here, I added the ability to explicitly trigger the referenced PFM using a new Notify Triggerer message node, which matches the behavior of PlasmaMax. The old "automatically notify any referenced PFMs when a state completes" is now an opt-in behavior exposed on the Responder State node. Existing Responder State nodes attached to Responder nodes with PFMs attached will default to this being ON. Newly created Responder State nodes will default to this being OFF. Basic Responders will require manual additions of Notify Trigger message nodes. I also fixed the auto notify messages to send the eventType of 1 instead of 0, matching the behavior of PlasmaMax.

An illustration of the changes:
<img width="987" height="673" alt="image" src="https://github.com/user-attachments/assets/ce7c284c-ee51-432f-9442-8fddcb1df7b8" />

I'm going to leave this open for feedback for a time, then merge. I have a set of SDL helper nodes that I'm curating that will need to be slightly updated for basic responders, so I'd like to go ahead and get this in.