### PR TITLE
Improve Handling of Parent-Child Relationships

### DIFF
--- a/korman/exporter/camera.py
+++ b/korman/exporter/camera.py
@@ -99,7 +99,7 @@ class CameraConverter:
             if manual_trans.camera:
                 # Don't even bother if a disabled camera is referenced. If we export camera modifier
                 # for a disabled camera, then it won't get a brain, and the client will crash.
-                if not manual_trans.camera.plasma_object.enabled:
+                if not self._exporter().is_enabled(manual_trans.camera):
                     continue
                 cam_trans.transTo = self._mgr.find_create_key(plCameraModifier, bl=manual_trans.camera)
             cam_trans.ignore = manual_trans.mode == "ignore"

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -176,6 +176,7 @@ class Exporter:
         self.report.progress_advance()
         self.report.progress_range = len(scene.objects)
         inc_progress = self.report.progress_increment
+        log_msg, error, warn = self.report.msg, self.report.error, self.report.warn
 
         # Grab a naive listing of enabled pages
         age = scene.world.plasma_age
@@ -196,6 +197,11 @@ class Exporter:
             default_enabled = True
             default_inited = False
 
+        def is_implicit_default(page: str):
+            if not default_enabled:
+                return False
+            return not page
+
         # Now we loop through the objects with some considerations:
         #     - The default page may or may not be defined. If it is, it can be disabled. If not, it
         #       can only ever be enabled.
@@ -203,20 +209,58 @@ class Exporter:
         #       to export a useless file.
         #     - Any arbitrary page can be disabled, so check our frozenset.
         #     - Also, someone might have specified an invalid page, so keep track of that.
-        error = explosions.UndefinedPageError()
-        for obj in scene.objects:
-            if obj.plasma_object.enabled:
-                page = obj.plasma_object.page
-                if not page and not default_inited:
-                    self.mgr.create_page(self.age_name, "Default", 0)
-                    default_inited = True
+        log_msg("\nCollecting objects for export...")
+        page_error = defaultdict(list)
+        with self.report.indent():
+            for obj in scene.objects:
+                if obj.plasma_object.enabled:
+                    page = obj.plasma_object.page
+                    if not page and not default_inited:
+                        self.mgr.create_page(self.age_name, "Default", 0)
+                        default_inited = True
 
-                if (default_enabled and not page) or (page in pages_enabled):
-                    self._objects.append(obj)
-                elif page not in all_pages or page in external_pages:
-                    error.add(page, obj.name)
-            inc_progress()
-        error.raise_if_error()
+                    # As part of this, ensure that the parent object is exported and prefer that
+                    # the entire object tree goes to the same page.
+                    has_parent = obj.parent is not None
+                    parent_name = obj.parent.name if obj.parent is not None else "<NO PARENT>"
+                    parent_page = obj.parent.plasma_object.page if obj.parent is not None else page
+
+                    if page and page not in all_pages or page in external_pages:
+                        # The object is in a page that doesn't exist or is marked external.
+                        # This check is a little bit extra in that pages that don't exist
+                        # should be disallowed by the RNA binding, but it could happen if the
+                        # page is deleted after an object is assigned to it.
+                        page_error[page].append(obj.name)
+                    elif has_parent and not obj.plasma_object.is_tree_enabled:
+                        # It's probably best to ignore a child object whose parent won't be
+                        # exported due to its being disabled.
+                        warn(f"Ignoring '{obj.name}' because its parent '{parent_name}' is not being exported")
+                    elif has_parent and not (parent_page in pages_enabled or is_implicit_default(parent_page)):
+                        # Same as above, except the parent object's page is disabled.
+                        warn(
+                            f"Ignoring '{obj.name}' because its parent '{parent_name}' "
+                            f"is in a disabled page ({parent_page or 'Default'})"
+                        )
+                    elif page in pages_enabled or is_implicit_default(page):
+                        # Having a child object in a different page than its parent object is,
+                        # strictly speaking, not a fatal error, but it could lead to unexpected
+                        # results. So, surface a visible error in this case, but don't stop
+                        # the export process.
+                        if has_parent and page != parent_page:
+                            error(
+                                f"'{obj.name}' is not in the same page as its parent '{parent_name}' "
+                                f"({parent_page or 'Default'})"
+                            )
+                        self._objects.append(obj)
+                    else:
+                        # Successful object ignore
+                        pass
+                inc_progress()
+
+        if page_error:
+            obj_names = "\n".join((f"    '{obj}': {page}" for page, objs in page_error.items() for obj in objs))
+            error_str = f"The following objects are in invalid pages:\n{obj_names}"
+            raise explosions.ExportError(error_str)
 
     def _check_sanity(self):
         self.report.progress_advance()
@@ -264,9 +308,14 @@ class Exporter:
                 parent_ci = self._export_coordinate_interface(None, parent)
                 parent_ci.addChild(so.key)
             else:
-                self.report.warn("You have parented Plasma Object '{}' to '{}', which has not been marked for export. \
-                                 The object may not appear in the correct location or animate properly.".format(
-                                    bo.name, parent.name))
+                # This should no longer happen - turning off a a parent object should supress
+                # all of its children. But, I'm leaving the log message in case that situation
+                # ever changes OR something slips through.
+                self.report.warn(
+                    f"You have parented Plasma Object '{bo.name}' to '{parent.name}', "
+                    "which has not been marked for export. The object may not appear in "
+                    "the correct location or animate properly."
+                )
 
     def _export_coordinate_interface(self, so, bl):
         """Ensures that the SceneObject has a CoordinateInterface"""

--- a/korman/exporter/convert.py
+++ b/korman/exporter/convert.py
@@ -467,6 +467,15 @@ class Exporter:
                     return True
         return False
 
+    def is_enabled(self, bl: bpy.types.Object) -> bool:
+        """
+        Just because an object's Plasma Object checkbox is marked enabled doesn't mean it will
+        be exported. This method returns a guaranteed YES when an object will be exported.
+        """
+        # This is maybe not the most performant way to do this check, but it will give us the
+        # right answer. It's done infrequently enough that it shouldn't be a big deal.
+        return bl in self._objects
+
     def _post_process_scene_objects(self):
         self.report.progress_advance()
         self.report.progress_range = len(self._objects)

--- a/korman/exporter/etlight.py
+++ b/korman/exporter/etlight.py
@@ -289,7 +289,7 @@ class LightBaker:
                 for obj in source:
                     if obj.plasma_object.has_animation_data:
                         continue
-                    if rtl_mod.rt_lights and obj.plasma_object.enabled:
+                    if rtl_mod.rt_lights and obj.plasma_object.is_tree_enabled:
                         continue
                     dest.objects.link(obj)
                     shouldibake = True

--- a/korman/exporter/explosions.py
+++ b/korman/exporter/explosions.py
@@ -72,25 +72,6 @@ class TooManyVerticesError(ExportError):
         super(ExportError, self).__init__(msg)
 
 
-class UndefinedPageError(ExportError):
-    mistakes = {}
-
-    def __init__(self):
-        super(ExportError, self).__init__("You have objects in invalid pages!")
-
-    def add(self, page, obj):
-        if page not in self.mistakes:
-            self.mistakes[page] = [obj,]
-        else:
-            self.mistakes[page].append(obj)
-
-    def raise_if_error(self):
-        if self.mistakes:
-            # Better give them some idea of what happened...
-            print(repr(self.mistakes))
-            raise self
-
-
 class UnsupportedTextureError(ExportError):
     def __init__(self, texture, material):
         super(ExportError, self).__init__("Cannot export texture '{}' on material '{}' -- unsupported type '{}'".format(texture.name, material.name, texture.type))

--- a/korman/exporter/logger.py
+++ b/korman/exporter/logger.py
@@ -199,7 +199,7 @@ class ExportProgressLogger(_ExportLogger):
         self._time_start_step = 0
 
     def __exit__(self, type, value, traceback):
-        if value is not None:
+        if value is not None and not isinstance(value, NonfatalExportError):
             export_time = time.perf_counter() - self._time_start_overall
             with self._print_condition:
                 self._progress_print_step(done=(self._step_progress == self._step_max), error=True)
@@ -374,7 +374,7 @@ class ExportVerboseLogger(_ExportLogger):
         super().__init__(True, age_path)
 
     def __exit__(self, type, value, traceback):
-        if value is not None:
+        if value is not None and not isinstance(value, NonfatalExportError):
             export_time = time.perf_counter() - self._time_start_overall
             self.msg("\nAborted after {:.2f}s", export_time)
             self.msg("Error: {}", value)

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -803,8 +803,8 @@ class MaterialConverter:
             # least a SceneObject and CoordInterface so that we can touch it...
             # NOTE: that harvest_actor makes sure everyone alread knows we're going to have a CI
             if isinstance(viewpt.data, bpy.types.Camera):
-                if not viewpt.plasma_object.enabled:
-                    raise ExportError(f"DynamicCamMap '{texture.name} wants to use the camera '{viewpt.name}', but it is not a Plasma Object!")
+                if not self._exporter().is_enabled(viewpt):
+                    raise ExportError(f"DynamicCamMap '{texture.name} wants to use the camera '{viewpt.name}', but it isn't being exported!")
                 pl_env.camera = self._mgr.find_create_key(plCameraModifier, bl=viewpt)
             else:
                 pl_env.rootNode = self._mgr.find_create_key(plSceneObject, bl=viewpt)

--- a/korman/exporter/rtlight.py
+++ b/korman/exporter/rtlight.py
@@ -267,7 +267,7 @@ class LightConverter:
                     if obj.type != "LAMP":
                         # moronic...
                         continue
-                    elif not obj.plasma_object.enabled:
+                    elif not obj.plasma_object.is_tree_enabled:
                         # who cares?
                         continue
                     lamp = obj.data

--- a/korman/properties/modifiers/game_gui.py
+++ b/korman/properties/modifiers/game_gui.py
@@ -1081,7 +1081,7 @@ class PlasmaGameGuiRadioGroupModifier(_GameGuiMixin, PlasmaModifierProperties):
         ctrl.setFlag(pfGUIRadioGroupCtrl.kAllowNoSelection, self.allow_no_selection)
         active_cbs = (
             i for i in self.iter_checkbox_mods(bpy.context)
-            if i.id_data.plasma_object.enabled
+            if exporter.is_enabled(i.id_data)
         )
         for i, cb_mod in enumerate(active_cbs):
             exporter.report.msg(f"Found checkbox '{cb_mod.id_data.name}'")

--- a/korman/properties/modifiers/sound.py
+++ b/korman/properties/modifiers/sound.py
@@ -31,6 +31,9 @@ from ...exporter import ExportError
 from ...helpers import copy_action, copy_object, GoodNeighbor, TemporaryCollectionItem
 from ... import idprops
 
+if TYPE_CHECKING:
+    from ...exporter import Exporter
+
 _randomsound_modes = {
     "normal": plRandomSoundMod.kNormal,
     "norepeat": plRandomSoundMod.kNoRepeats,
@@ -613,10 +616,10 @@ class PlasmaSoundEmitter(PlasmaModifierProperties):
             yield emitter_obj
             setattr(self, attr, emitter_obj)
 
-    def _find_animation_groups(self, bo: bpy.types.Object):
+    def _find_animation_groups(self, exporter: Exporter, bo: bpy.types.Object):
         is_anim_group = lambda x: (
             x is not bo and
-            x.plasma_object.enabled and
+            exporter.is_enabled(x) and
             x.plasma_modifiers.animation_group.enabled
         )
         for i in filter(is_anim_group, bpy.data.objects):
@@ -649,7 +652,7 @@ class PlasmaSoundEmitter(PlasmaModifierProperties):
             # that those animations are targetted by anyone trying to control us. That's an
             # animation group modifier (plMsgForwarder) for anyone playing along at home.
             if self.stereize_left.plasma_object.has_animation_data or self.stereize_right.plasma_object.has_animation_data:
-                my_anim_groups = list(self._find_animation_groups(bo))
+                my_anim_groups = list(self._find_animation_groups(exporter, bo))
 
                 # If no one contains this sound emitter, then we need to be an animation group.
                 if not my_anim_groups:

--- a/korman/properties/prop_object.py
+++ b/korman/properties/prop_object.py
@@ -82,6 +82,21 @@ class PlasmaObject(bpy.types.PropertyGroup):
         return False
 
     @property
+    def is_tree_enabled(self):
+        """
+        Is the "Plasma Object" checkbox enabled on this object and all of its parents?
+        This should be the preferred way to detect if an object is likely to be exported, instead of
+        querying the enabled UI property. This way if a parent object is disabled, the entire tree
+        will be squelched.
+        """
+        bo = self.id_data
+        while bo is not None:
+            if not bo.plasma_object.enabled:
+                return False
+            bo = bo.parent
+        return True
+
+    @property
     def subworld(self):
         bo = self.id_data
         while bo is not None:

--- a/korman/ui/ui_object.py
+++ b/korman/ui/ui_object.py
@@ -45,13 +45,15 @@ class PlasmaObjectPanel(ObjectButtonsPanel, bpy.types.Panel):
     bl_label = "Plasma Object"
 
     def draw_header(self, context):
-        self.layout.prop(context.object.plasma_object, "enabled", text="")
+        layout = self.layout
+        layout.active = context.object.plasma_object.is_tree_enabled
+        layout.prop(context.object.plasma_object, "enabled", text="")
 
     def draw(self, context):
         layout = self.layout
         pl_obj = context.object.plasma_object
         pl_age = context.scene.world.plasma_age
-        layout.active = pl_obj.enabled
+        tree_enabled = pl_obj.is_tree_enabled
 
         # It is an error to put objects in the wrong types of pages/
         active_page = next((i for i in pl_age.pages if i.name == pl_obj.page), None)
@@ -59,11 +61,14 @@ class PlasmaObjectPanel(ObjectButtonsPanel, bpy.types.Panel):
 
         # Which page does this object go in?
         # If left blank, the exporter puts it in page 0 -- "Default"
+        layout.active = tree_enabled
         layout.alert = is_external_page
         layout.prop_search(pl_obj, "page", pl_age, "pages", icon="BOOKMARKS")
         layout.alert = False
         if is_external_page:
             layout.label("Objects cannot be exported to External pages.", icon="ERROR")
+        if not tree_enabled:
+            layout.label("Parent object is disabled.", icon="ERROR")
 
 
 class PlasmaNetPanel(ObjectButtonsPanel, bpy.types.Panel):


### PR DESCRIPTION
This PR improves the parent/child object process by showing a noisy warning at the end of the export if an object is parented to an object in another page. Also, for safety, if a parent object is disabled either explicitly or by being in a disabled page, that child object is implicitly disabled, and a warning is printed to the log.

These mitigations should fix #453.