### PR TITLE
Add SDL Logic Nodes

### DIFF
--- a/korman/nodes/node_conditions.py
+++ b/korman/nodes/node_conditions.py
@@ -490,6 +490,72 @@ class PlasmaLinkEventNode(PlasmaNodeBase, bpy.types.Node):
         self._add_py_parameter(pfm, 101, plPythonParameter.kString, self.trigger_for)
         self._add_py_parameter(pfm, 102, plPythonParameter.kString, self.trigger_at)
 
+
+class PlasmaSDLBoolConditionNode(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "CONDITIONS"
+    bl_idname = "PlasmaSDLBoolConditionNode"
+    bl_label = "SDL Boolean Condition"
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "condition": {
+            "text": "Condition",
+            "type": "PlasmaConditionSocket",
+        },
+        "variable": {
+            "text": "Depends on SDL",
+            "type": "PlasmaSDLTriggererSocket",
+        },
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "satisfies_true": {
+            "text": "Trigger on True",
+            "type": "PlasmaConditionSocket",
+            "valid_link_nodes": {"PlasmaResponderNode", "PlasmaBasicResponderNode"}
+        },
+        "satisfies_false": {
+            "text": "Trigger on False",
+            "type": "PlasmaConditionSocket",
+            "valid_link_nodes": {"PlasmaResponderNode", "PlasmaBasicResponderNode"},
+        }
+    }
+
+    ffwd_init = BoolProperty(
+        name="F-Fwd on Init",
+        description="Fast-forward the matching Responder when the Age loads",
+        default=True,
+        options=set()
+    )
+
+    def draw_buttons(self, context, layout: bpy.types.UILayout):
+        layout.prop(self, "ffwd_init")
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        condition_node = self.find_input("condition")
+        variable_node = self.find_input("variable")
+        if condition_node is None:
+            self.raise_error("Must be linked to a condition")
+        if variable_node is None:
+            self.raise_error("Must be linked to an SDL variable")
+
+        # xAgeSDLBoolCondResp only handles one SDL value per modifier. We're exposing two
+        # node sockets as a convenience to match the behavior of the xAgeSDLBoolRespond node.
+        # This means we'll potentially be producing two PFMs here.
+        resp_socket_names = ("satisfies_false", "satisfies_true")
+        for i, resp_node_iter in enumerate((self.find_outputs(i) for i in resp_socket_names)):
+            resp_nodes = tuple(resp_node_iter)
+            if not resp_nodes:
+                continue
+
+            pfm = self._find_create_object(plPythonFileMod, exporter, so=so, suffix=str(i))
+            pfm.filename = "xAgeSDLBoolCondResp"
+            self._add_py_parameter(pfm, 1, plPythonParameter.kActivator, condition_node.get_key(exporter, so))
+            self._add_py_parameter(pfm, 2, plPythonParameter.kString, variable_node.variable_name)
+            for resp_node in resp_nodes:
+                self._add_py_parameter(pfm, 3, plPythonParameter.kResponder, resp_node.get_key(exporter, so))
+            self._add_py_parameter(pfm, 4, plPythonParameter.kBoolean, i == 1)
+            self._add_py_parameter(pfm, 5, plPythonParameter.kBoolean, self.ffwd_init)
+
     @property
     def export_once(self):
         return True

--- a/korman/nodes/node_core.py
+++ b/korman/nodes/node_core.py
@@ -346,21 +346,39 @@ class PlasmaNodeBase:
         # Create any missing sockets and spawn any required empties.
         for alias, options in defs.items():
             working_sockets = [(i, socket) for i, socket in enumerate(sockets) if socket.alias == alias]
+            num_sockets = options.get("min_sockets", 1)
+            num_used = sum((1 for i, socket in working_sockets if socket.is_linked))
             if not working_sockets:
-                self._spawn_socket(alias, options, sockets)
-            elif options.get("spawn_empty", False):
-                last_socket_id = next(reversed(working_sockets))[0]
-                for working_id, working_socket in working_sockets:
-                    if working_id == last_socket_id and working_socket.is_linked:
-                        new_socket_id = len(sockets)
-                        new_socket = self._spawn_socket(alias, options, sockets)
-                        desired_id = last_socket_id + 1
-                        if new_socket_id != desired_id:
-                            sockets.move(new_socket_id, desired_id)
-                    elif working_id < last_socket_id and not working_socket.is_linked:
+                for _ in range(num_sockets):
+                    self._spawn_socket(alias, options, sockets)
+            else:
+                last_socket_id = working_sockets[-1][0]
+                if options.get("spawn_empty", False):
+                    num_sockets = max(num_sockets, num_used + 1)
+
+                # Gather the sockets we have that are disconnected and preferentially remove the
+                # ones from the front of the list until we reach the minimum number of required
+                # sockets.
+                sockets_to_kill = len(working_sockets) - num_sockets
+                if sockets_to_kill > 0:
+                    dead_sockets = [
+                        i for i, (working_id, working_socket) in enumerate(working_sockets)
+                        if not working_socket.is_linked
+                    ]
+                    for i in reversed(dead_sockets[:sockets_to_kill]):
                         # Indices do not update until after the update() function finishes, so
                         # no need to decrement last_socket_id
-                        sockets.remove(working_socket)
+                        sockets.remove(working_sockets.pop(i)[1])
+
+                # Ensure that we have the minimum number of sockets spawned. This code will
+                # generally not execute.
+                insert_at = last_socket_id + 1
+                for i in range(len(working_sockets), num_sockets):
+                    new_socket_id = len(sockets)
+                    new_socket = self._spawn_socket(alias, options, sockets)
+                    if new_socket_id != insert_at:
+                        sockets.move(new_socket_id, insert_at)
+                    insert_at += 1
 
     def _update_extant_sockets(self, defs, sockets):
         # Manually enumerate the sockets that are present for their presence and for the

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -458,6 +458,135 @@ class PlasmaSDLBoolTriggerNode(PlasmaNodeBase, bpy.types.Node):
         return True
 
 
+class SDLRespMap(bpy.types.PropertyGroup):
+    value = IntProperty(
+        name="SDL Value",
+        description="SDL value that we should use to trigger the Responder",
+        options=set()
+    )
+
+    state = IntProperty(
+        name="Responder State",
+        description="State ID we should trigger on the Responder",
+        min=0,
+        options=set(),
+        subtype="UNSIGNED"
+    )
+
+
+class PlasmaSDLIntTrigger(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "LOGIC"
+    bl_idname = "PlasmaSDLIntTriggerNode"
+    bl_label = "SDL Integer Trigger"
+    bl_width_default = 200
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "variable": {
+            "text": "Triggered by SDL",
+            "type": "PlasmaSDLTriggererSocket",
+        },
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "satisfies": {
+            "text": "Trigger on Match",
+            "type": "PlasmaConditionSocket",
+            "link_limit": 1,
+            # Because this node expects to use responder states, basic responders have no place
+            # being linked here. Sorry.
+            "valid_link_nodes": {"PlasmaResponderNode"},
+        },
+    }
+
+    behavior = EnumProperty(
+        name="Trigger",
+        description="Define the strategy for triggering the attached Responder's states",
+        items=[
+            ("FIRE_STATE", "Matching", "Trigger the state ID matching the SDL Variable's value as shown in Korman"),
+            ("MAP_STATE", "Mapped", "Use a manual SDL value to Responder State mapping"),
+        ],
+        options=set()
+    )
+    state_map = CollectionProperty(type=SDLRespMap)
+    ffwd_init = BoolProperty(
+        name="F-Fwd on Init",
+        description="Fast-forward the matching Responder when the Age loads",
+        default=True,
+        options=set()
+    )
+    ffwd_vm = BoolProperty(
+        name="F-Fwd on VM",
+        description="Fast-forward the matching Responder when the SDL variable is changed in the Vault Manager",
+        default=True,
+        options=set()
+    )
+
+    def count_num_resp_states(self, resp_node: Optional[PlasmaNodeBase]) -> int:
+        if resp_node is None:
+            return 0
+        return sum((1 for _ in resp_node.find_outputs("state_refs")))
+
+    def draw_buttons(self, context, layout: bpy.types.UILayout):
+        layout.prop(self, "behavior")
+        if self.behavior == "MAP_STATE":
+            draw_node_list(
+                self,
+                layout,
+                "state_map",
+                self._draw_value,
+                footer="Add SDL State"
+            )
+        layout.prop(self, "ffwd_init")
+        layout.prop(self, "ffwd_vm")
+
+    def _draw_value(self, item: SDLRespMap, layout: bpy.types.UILayout):
+        other_input_values = frozenset((i.value for i in self.state_map if i != item))
+        num_states = self.count_num_resp_states(self.find_output("satisfies"))
+        layout.alert = item.value in other_input_values
+        layout.prop(item, "value", text="SDL")
+        layout.alert = item.state >= num_states
+        layout.prop(item, "state", text="ID")
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        input_variable = self.find_input("variable")
+        if input_variable is None:
+            self.raise_error("Must be linked to an input SDL variable")
+
+        resp_node = self.find_output("satisfies")
+        if resp_node is None:
+            self.raise_error("Must be linked to a Responder node")
+
+        pfm = self._find_create_object(plPythonFileMod, exporter, so=so)
+        pfm.filename = "xAgeSDLIntStateListResp"
+        self._add_py_parameter(pfm, 1, plPythonParameter.kString, input_variable.variable_name)
+        self._add_py_parameter(pfm, 2, plPythonParameter.kResponder, resp_node.get_key(exporter, so))
+        self._add_py_parameter(
+            pfm, 3, plPythonParameter.kString,
+            "".join((f"({i},{j})" for i, j in self._iter_items(resp_node)))
+        )
+        self._add_py_parameter(pfm, 4, plPythonParameter.kBoolean, self.ffwd_init)
+        self._add_py_parameter(pfm, 5, plPythonParameter.kBoolean, self.ffwd_vm)
+
+    def _iter_items(self, resp_node: PlasmaNodeBase) -> Iterator[Tuple[int, int]]:
+        num_states = self.count_num_resp_states(resp_node)
+        if self.behavior == "FIRE_STATE":
+            for i in range(num_states):
+                yield i, i
+        elif self.behavior == "MAP_STATE":
+            counter = Counter((str(i.value) for i in self.state_map))
+            dupe_values = [str(i) for i, j in counter.items() if j > 1]
+            if dupe_values:
+                self.raise_error(f"The following SDL Values are duplicated: '{f', '.join(dupe_values)}'")
+            oob_states = frozenset((str(i.state) for i in self.state_map if i.state >= num_states))
+            if oob_states:
+                self.raise_error(f"The following Responder states do not exist: '{f', '.join(oob_states)}'")
+
+            for i in self.state_map:
+                yield i.value, i.state
+        else:
+            raise ValueError(self.behavior)
+
+
 class PlasmaSDLSocketBase:
     bl_color = (0.18, 0.55, 0.34, 1.0)
 

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -310,6 +310,74 @@ class PlasmaExcludeMessageSocket(PlasmaNodeSocketBase, bpy.types.NodeSocket):
     bl_color = (0.467, 0.576, 0.424, 1.0)
 
 
+class PlasmaSDLBoolGateNode(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "LOGIC"
+    bl_idname = "PlasmaSDLBoolGateNode"
+    bl_label = "SDL Boolean Gate"
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "input_variable": {
+            "text": "Input SDL",
+            "type": "PlasmaSDLTriggererSocket",
+            "spawn_empty": True,
+        },
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "output_variable": {
+            "text": "Output SDL",
+            "type": "PlasmaSDLTriggereeSocket",
+            "link_limit": 1,
+        }
+    }
+
+    operation = EnumProperty(
+        name="Operation",
+        description="Boolean operation to apply to the input SDL variables",
+        items=[
+            ("AND", "AND", "Perform a logical AND"),
+            ("OR", "OR", "Perform a logical OR"),
+            ("NAND", "NAND", "Perform a logical NOT AND"),
+            ("XOR", "XOR", "Perform a logical eXclusive OR"),
+        ],
+        default="AND",
+        options=set()
+    )
+
+    def draw_buttons(self, context, layout: bpy.types.UILayout):
+        layout.props_enum(self, "operation")
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        input_sdl_variables = frozenset((i.variable_name for i in self.find_inputs("input_variable")))
+        output_sdl_node = self.find_output("output_variable")
+        if len(input_sdl_variables) < 2:
+            self.raise_error("At least two unique input SDL variables must be connected")
+        if output_sdl_node is None:
+            self.raise_error("Output SDL variable must be connected")
+
+        # The only SDL boolean gate script that exists out of the box is xAgeSDLBoolAndSet. This
+        # script takes two SDL variables, performs a logical AND, and stores the result in a third
+        # variable. I wrote xAgeSDLBoolAndSetV2 or take an arbitrary number of variables, AND them,
+        # and store the result. Since I was working, I also took the liberty of writing xAgeSDLBoolOrSet,
+        # which should be self explanatory. Because we have quite a few nonstandard scripts, let's
+        # special case AND with two variables for the standard script.
+        pfm = self._find_create_object(plPythonFileMod, exporter, so=so)
+        if self.operation == "AND" and len(input_sdl_variables) == 2:
+            pfm.filename = "xAgeSDLBoolAndSet"
+            sdl_node_iter = itertools.chain(input_sdl_variables, (output_sdl_node.variable_name,))
+            for attr_id, sdl_var in enumerate(sdl_node_iter, start=1):
+                self._add_py_parameter(pfm, attr_id, plPythonParameter.kString, sdl_var)
+        else:
+            pfm.filename = "xAgeSDLBoolGateSet"
+            self._add_py_parameter(pfm, 1, plPythonParameter.kString, ",".join(input_sdl_variables))
+            self._add_py_parameter(pfm, 2, plPythonParameter.kString, output_sdl_node.variable_name)
+            self._add_py_parameter(pfm, 3, plPythonParameter.kString, self.operation)
+
+    @property
+    def export_once(self) -> bool:
+        return True
+
+
 class PlasmaSDLBoolTriggerNode(PlasmaNodeBase, bpy.types.Node):
     bl_category = "LOGIC"
     bl_idname = "PlasmaSDLBoolTriggerNode"

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -319,6 +319,7 @@ class PlasmaSDLBoolGateNode(PlasmaNodeBase, bpy.types.Node):
         "input_variable": {
             "text": "Input SDL",
             "type": "PlasmaSDLTriggererSocket",
+            "min_sockets": 2,
             "spawn_empty": True,
         },
     }

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -21,8 +21,178 @@ from typing import *
 from PyHSPlasma import *
 
 from .. import enum_props
+from ..exporter import Exporter
 from .node_core import *
 from .. import idprops
+
+class PlasmaChangeSDLNode(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "LOGIC"
+    bl_idname = "PlasmaChangeSDLNode"
+    bl_label = "Change SDL"
+    bl_width_default = 200
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "condition": {
+            "text": "Condition",
+            "type": "PlasmaConditionSocket",
+            "spawn_empty": True,
+        },
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "variable": {
+            "text": "SDL",
+            "type": "PlasmaSDLTriggereeSocket",
+        }
+    }
+
+    action = EnumProperty(
+        name="Action",
+        items=[
+            ("TOGGLE", "Toggle Boolean", "Toggle a boolean SDL variable"),
+            ("SET_BOOL", "Set Boolean", "Set the boolean value of an SDL Variable"),
+            ("SET_INT", "Set Integer", "Set the integer value of an SDL Variable"),
+            ("INC_INT", "Increment Integer", "Increment the integer value of an SDL Variable"),
+            ("DEC_INT", "Decrement Integer", "Decrement the integer value of an SDL Variable"),
+        ],
+        options=set()
+    )
+
+    value_int = IntProperty(
+        name="Value",
+        options=set()
+    )
+
+    def _get_bool(self) -> bool:
+        return self.value_int != 0
+    def _set_bool(self, value: bool) -> None:
+        if self.value_int == 0 and value:
+            self.value_int = 1
+        if self.value_int != 0 and not value:
+            self.value_int = 0
+
+    value_bool = BoolProperty(
+        name="Value",
+        description="If checked, the value of the SDL Variable is true",
+        get=_get_bool,
+        set=_set_bool,
+        options=set()
+    )
+
+    count_behavior = EnumProperty(
+        name="Behavior",
+        description="",
+        items=[
+            ("UNBOUNDED", "[None]", "Don't use bounds for the SDL value"),
+            ("CLAMP", "Clamp", "Clamp the SDL value to the range provided"),
+            ("LOOP", "Loop", "Loop the SDL value within the range provided"),
+        ]
+    )
+
+    min_value = IntProperty(
+        name="Min",
+        description="Minimum value of the SDL variable",
+        default=0,
+        options=set()
+    )
+    max_value = IntProperty(
+        name="Max",
+        description="Maximum value of the SDL variable",
+        default=10,
+        options=set()
+    )
+
+    tag_string = StringProperty(
+        name="Extra Info",
+        description="Tag string sent along as extra info for the SDL variable change",
+        options=set()
+    )
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "action")
+        if self.action == "SET_BOOL":
+            layout.prop(self, "value_bool")
+        elif self.action == "SET_INT":
+            layout.prop(self, "value_int")
+        elif self.action in {"INC_INT", "DEC_INT"}:
+            layout.prop(self, "count_behavior")
+            if self.count_behavior != "UNBOUNDED":
+                row = layout.row(align=True)
+                row.alert = self.min_value >= self.max_value
+                row.prop(self, "min_value")
+                row.prop(self, "max_value")
+        elif self.action == "TOGGLE":
+            pass
+        else:
+            raise ValueError(self.action)
+
+        layout.prop(self, "tag_string")
+
+    def get_key(self, exporter: Exporter, so: plSceneObject) -> plKey[plPythonFileMod]:
+        return self._find_create_key(plPythonFileMod, exporter, so=so)
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        variable_node = self.find_output("variable")
+        if variable_node is None:
+            self.raise_error("Must be connected to an SDL Variable")
+
+        # While we could technically use a thunk to simplify this, unfortunately, plAACO won't
+        # pass through the details about which avatar did the deed. xAgeSDLBoolToggle uses the
+        # anti-pattern `if PtFindAvatar(events) == PtGetLocalAvatar()` to detect if a notification
+        # is local. So, we'll connect the PFM directly to the host LogicMod.
+        logic_keys = [i.get_key(exporter, so) for i in self.find_inputs("condition")]
+        logic_keys_iter = (i for i in logic_keys if i is not None)
+        if not any(logic_keys):
+            self.raise_error("Must be connected to valid conditions!")
+
+        pfm = self._find_create_object(plPythonFileMod, exporter, so=so)
+        if self.action == "TOGGLE":
+            pfm.filename = "xAgeSDLBoolToggle"
+            for i in logic_keys_iter:
+                self._add_py_parameter(pfm, 1, plPythonParameter.kActivator, i)
+            self._add_py_parameter(pfm, 2, plPythonParameter.kString, variable_node.variable_name)
+            if self.tag_string:
+                self._add_py_parameter(pfm, 5, plPythonParameter.kString, self.tag_string)
+        elif self.action == "SET_BOOL":
+            pfm.filename = "xAgeSDLBoolSet"
+            for i in logic_keys_iter:
+                self._add_py_parameter(pfm, 1, plPythonParameter.kActivator, i)
+            self._add_py_parameter(pfm, 2, plPythonParameter.kString, variable_node.variable_name)
+            self._add_py_parameter(pfm, 7, plPythonParameter.kInt, self.value_int)
+            if self.tag_string:
+                self._add_py_parameter(pfm, 8, plPythonParameter.kString, self.tag_string)
+        elif self.action in {"INC_INT", "DEC_INT", "SET_INT"}:
+            pfm.filename = "xAgeSDLIntChange"
+            for i in logic_keys_iter:
+                self._add_py_parameter(pfm, 1, plPythonParameter.kActivator, i)
+            self._add_py_parameter(pfm, 2, plPythonParameter.kString, variable_node.variable_name)
+            self._add_py_parameter(pfm, 3, plPythonParameter.kBoolean, self.action == "INC_INT")
+            self._add_py_parameter(pfm, 4, plPythonParameter.kBoolean, self.action == "DEC_INT")
+            if self.action != "SET_INT":
+                # The xAgeSDLIntChange script doesn't really have an "unbounded" mode. But,
+                # we can fake it by passing in the min/max values of the underlying signed
+                # 32-bit integer store.
+                if self.count_behavior == "UNBOUNDED":
+                    min_value, max_value = -2**31, 2**31-1
+                else:
+                    min_value = min(self.min_value, self.max_value)
+                    max_value = max(self.min_value, self.max_value)
+                if min_value == max_value:
+                    self.raise_error("Minimum and maximum values must not be the same!")
+                self._add_py_parameter(pfm, 5, plPythonParameter.kInt, min_value)
+                self._add_py_parameter(pfm, 6, plPythonParameter.kInt, max_value)
+                self._add_py_parameter(pfm, 7, plPythonParameter.kBoolean, self.count_behavior == "LOOP")
+            if self.tag_string:
+                self._add_py_parameter(pfm, 8, plPythonParameter.kString, self.tag_string)
+            if self.action == "SET_INT":
+                self._add_py_parameter(pfm, 9, plPythonParameter.kInt, self.value_int)
+        else:
+            raise ValueError(self.action)
+
+    @property
+    def export_once(self):
+        return True
+
 
 class PlasmaExcludeRegionNode(idprops.IDPropObjectMixin, PlasmaNodeBase, bpy.types.Node):
     bl_category = "LOGIC"
@@ -137,3 +307,42 @@ class PlasmaExcludeSafePointSocket(idprops.IDPropObjectMixin, PlasmaNodeSocketBa
 
 class PlasmaExcludeMessageSocket(PlasmaNodeSocketBase, bpy.types.NodeSocket):
     bl_color = (0.467, 0.576, 0.424, 1.0)
+
+
+class PlasmaSDLSocketBase:
+    bl_color = (0.18, 0.55, 0.34, 1.0)
+
+
+class PlasmaSDLTriggererSocket(PlasmaSDLSocketBase, PlasmaNodeSocketBase, bpy.types.NodeSocket): pass
+class PlasmaSDLTriggereeSocket(PlasmaSDLSocketBase, PlasmaNodeSocketBase, bpy.types.NodeSocket): pass
+
+
+class PlasmaSDLVariableNode(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "LOGIC"
+    bl_idname = "PlasmaSDLVariableNode"
+    bl_label = "SDL Variable"
+    bl_width_default = 200
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "condition": {
+            "text": "Changed By",
+            "type": "PlasmaSDLTriggereeSocket",
+        }
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "satisfies": {
+            "text": "Triggers",
+            "type": "PlasmaSDLTriggererSocket",
+        }
+    }
+
+    variable_name = StringProperty(
+        name="Variable",
+        description="Name of an SDL Variable",
+        options=set()
+    )
+
+    def draw_buttons(self, context, layout: bpy.types.UILayout):
+        layout.alert = not self.variable_name.strip()
+        layout.prop(self, "variable_name")

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -692,6 +692,109 @@ class PlasmaSDLValueMapNode(PlasmaNodeBase, bpy.types.Node):
             yield (i.input_value, i.output_value)
 
 
+
+class SDLMatchValue(bpy.types.PropertyGroup):
+    value = IntProperty(
+        name="SDL Value",
+        description="",
+        default=1,
+        options=set()
+    )
+
+
+class PlasmaSDLValueTriggerNode(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "LOGIC"
+    bl_idname = "PlasmaSDLValueTriggerNode"
+    bl_label = "SDL Value Trigger"
+    bl_width_default = 170
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "input_variable": {
+            "text": "Triggered by SDL",
+            "type": "PlasmaSDLTriggererSocket",
+        },
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "satisfies_true": {
+            "text": "Trigger on Match",
+            "type": "PlasmaConditionSocket",
+            "valid_link_nodes": {"PlasmaResponderNode", "PlasmaBasicResponderNode"},
+        },
+        "satisfies_false": {
+            "text": "Trigger on Mismatch",
+            "type": "PlasmaConditionSocket",
+            "valid_link_nodes": {"PlasmaResponderNode", "PlasmaBasicResponderNode"},
+        }
+    }
+
+    states = CollectionProperty(type=SDLMatchValue)
+    ffwd_init = BoolProperty(
+        name="F-Fwd on Init",
+        description="Fast-forward the appropriate Responder when the Age loads",
+        default=True,
+        options=set()
+    )
+    ffwd_true = BoolProperty(
+        name="F-Fwd on Match",
+        description="Fast-forward the Responder attached to the match socket",
+        options=set()
+    )
+    ffwd_false = BoolProperty(
+        name="F-Fwd on Mismatch",
+        description="Fast-forward the Responder attached to the mismatch socket",
+        options=set()
+    )
+    ffwd_vm = BoolProperty(
+        name="F-Fwd on VM",
+        description="Fast-forward the appropriate Responder when the SDL variable is changed in the Vault Manager",
+        default=True,
+        options=set()
+    )
+
+    def init(self, context):
+        self.states.add()
+
+    def draw_buttons(self, context, layout: bpy.types.UILayout):
+        draw_node_list(
+            self,
+            layout,
+            "states",
+            self._draw_state,
+            footer="Add New State"
+        )
+        layout.prop(self, "ffwd_init")
+        layout.prop(self, "ffwd_true")
+        layout.prop(self, "ffwd_false")
+        layout.prop(self, "ffwd_vm")
+
+    def _draw_state(self, state, layout: bpy.types.UILayout):
+        layout.alert = any((state.value == i.value for i in self.states if i != state))
+        layout.prop(state, "value")
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        input_variable = self.find_input("input_variable")
+        if input_variable is None:
+            self.raise_error("Must be linked to an input SDL variable")
+
+        pfm = self._find_create_object(plPythonFileMod, exporter, so=so)
+        pfm.filename = "xAgeSDLIntStartStopResp"
+        self._add_py_parameter(pfm, 1, plPythonParameter.kString, input_variable.variable_name)
+        for i in self.find_outputs("satisfies_true"):
+            self._add_py_parameter(pfm, 2, plPythonParameter.kResponder, i.get_key(exporter, so))
+        self._add_py_parameter(pfm, 3, plPythonParameter.kString, ",".join((str(i.value) for i in self.states)))
+        self._add_py_parameter(pfm, 4, plPythonParameter.kBoolean, self.ffwd_true)
+        for i in self.find_outputs("satisfies_false"):
+            self._add_py_parameter(pfm, 5, plPythonParameter.kResponder, i.get_key(exporter, so))
+        self._add_py_parameter(pfm, 6, plPythonParameter.kBoolean, self.ffwd_false)
+        self._add_py_parameter(pfm, 8, plPythonParameter.kBoolean, self.ffwd_init)
+        self._add_py_parameter(pfm, 9, plPythonParameter.kBoolean, self.ffwd_vm)
+
+    @property
+    def export_once(self):
+        return True
+
+
 class PlasmaSDLVariableNode(PlasmaNodeBase, bpy.types.Node):
     bl_category = "LOGIC"
     bl_idname = "PlasmaSDLVariableNode"

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import bpy
 from bpy.props import *
+import itertools
 from typing import *
 from PyHSPlasma import *
 
@@ -307,6 +308,83 @@ class PlasmaExcludeSafePointSocket(idprops.IDPropObjectMixin, PlasmaNodeSocketBa
 
 class PlasmaExcludeMessageSocket(PlasmaNodeSocketBase, bpy.types.NodeSocket):
     bl_color = (0.467, 0.576, 0.424, 1.0)
+
+
+class PlasmaSDLBoolTriggerNode(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "LOGIC"
+    bl_idname = "PlasmaSDLBoolTriggerNode"
+    bl_label = "SDL Boolean Trigger"
+    bl_width_default = 170
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "variable": {
+            "text": "Triggered by SDL",
+            "type": "PlasmaSDLTriggererSocket",
+        },
+        "dependent": {
+            "text": "Dependends on SDL",
+            "type": "PlasmaSDLTriggererSocket",
+        }
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "satisfies_true": {
+            "text": "Trigger on True",
+            "type": "PlasmaConditionSocket",
+            "valid_link_nodes": {"PlasmaResponderNode", "PlasmaBasicResponderNode"},
+        },
+        "satisfies_false": {
+            "text": "Trigger on False",
+            "type": "PlasmaConditionSocket",
+            "valid_link_nodes": {"PlasmaResponderNode", "PlasmaBasicResponderNode"},
+        }
+    }
+
+    ffwd_init = BoolProperty(
+        name="F-Fwd on Init",
+        description="Fast-forward the matching Responder when the Age loads",
+        default=True,
+        options=set()
+    )
+    ffwd_vm = BoolProperty(
+        name="F-Fwd on VM",
+        description="Fast-forward the matching Responder when the SDL variable is changed in the Vault Manager",
+        default=True,
+        options=set()
+    )
+
+    def draw_buttons(self, context, layout: bpy.types.UILayout):
+        layout.prop(self, "ffwd_init")
+        layout.prop(self, "ffwd_vm")
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        trigger_var = self.find_input("variable")
+        dependent_var = self.find_input("dependent")
+        if trigger_var is None:
+            self.raise_error("Must be linked to an SDL variable")
+
+        # We're going to pick between xAgeSDLBoolRespond and xAgeSDLBoolAndRespond. The attributes
+        # are the same except the latter has an extra dependent variable as attribute 2. To avoid
+        # having to recode everything for the different IDs, we'll just use a counter.
+        attr_id_iter = itertools.count(1)
+        pfm = self._find_create_object(plPythonFileMod, exporter, so=so)
+        pfm.filename = "xAgeSDLBoolAndRespond" if dependent_var is not None else "xAgeSDLBoolRespond"
+        self._add_py_parameter(pfm, next(attr_id_iter), plPythonParameter.kString, trigger_var.variable_name)
+        if dependent_var is not None:
+            self._add_py_parameter(pfm, next(attr_id_iter), plPythonParameter.kString, dependent_var.variable_name)
+
+        # Important: attr_id_iter should be the second argument to zip() so that no elements are
+        # consumed from the counter when the responder name tuple is exhausted.
+        for resp_name, attr_id in zip(("satisfies_true", "satisfies_false"), attr_id_iter):
+            for resp_node in self.find_outputs(resp_name):
+                self._add_py_parameter(pfm, attr_id, plPythonParameter.kResponder, resp_node.get_key(exporter, so))
+
+        self._add_py_parameter(pfm, next(attr_id_iter), plPythonParameter.kBoolean, self.ffwd_vm)
+        self._add_py_parameter(pfm, next(attr_id_iter), plPythonParameter.kBoolean, self.ffwd_init)
+
+    @property
+    def export_once(self):
+        return True
 
 
 class PlasmaSDLSocketBase:

--- a/korman/nodes/node_logic.py
+++ b/korman/nodes/node_logic.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import bpy
 from bpy.props import *
+from collections import Counter
 import itertools
 from typing import *
 from PyHSPlasma import *
@@ -25,6 +26,7 @@ from .. import enum_props
 from ..exporter import Exporter
 from .node_core import *
 from .. import idprops
+from ..ui.ui_list import draw_node_list
 
 class PlasmaChangeSDLNode(PlasmaNodeBase, bpy.types.Node):
     bl_category = "LOGIC"
@@ -462,6 +464,103 @@ class PlasmaSDLSocketBase:
 
 class PlasmaSDLTriggererSocket(PlasmaSDLSocketBase, PlasmaNodeSocketBase, bpy.types.NodeSocket): pass
 class PlasmaSDLTriggereeSocket(PlasmaSDLSocketBase, PlasmaNodeSocketBase, bpy.types.NodeSocket): pass
+
+
+class SDLValueMap(bpy.types.PropertyGroup):
+    input_value = IntProperty(
+        name="Original State",
+        description="Original SDL Value that we're going to convert from",
+        options=set()
+    )
+
+    output_value = IntProperty(
+        name="New State",
+        description="Output SDL Value that we will convert to",
+        options=set()
+    )
+
+
+class PlasmaSDLValueMapNode(PlasmaNodeBase, bpy.types.Node):
+    bl_category = "LOGIC"
+    bl_idname = "PlasmaSDLValueMapNode"
+    bl_label = "SDL Value Map"
+    bl_width_default = 250
+
+    input_sockets: dict[str, dict[str, Any]] = {
+        "input_variable": {
+            "text": "Input SDL",
+            "type": "PlasmaSDLTriggererSocket",
+        },
+    }
+
+    output_sockets: dict[str, dict[str, Any]] = {
+        "output_variable": {
+            "text": "Output SDL",
+            "type": "PlasmaSDLTriggereeSocket",
+            "link_limit": 1,
+        }
+    }
+
+    tag_string = StringProperty(
+        name="Extra Info",
+        description="Tag string sent along as extra info for the SDL variable change",
+        options=set()
+    )
+
+    value_map = CollectionProperty(type=SDLValueMap)
+
+    def draw_buttons(self, context, layout: bpy.types.UILayout):
+        draw_node_list(
+            self,
+            layout,
+            "value_map",
+            self._draw_value,
+            header="Map SDL Values",
+            footer="Add New Mapping"
+        )
+        layout.prop(self, "tag_string")
+
+    def _draw_value(self, value: SDLValueMap, layout: bpy.types.UILayout):
+        other_input_values = frozenset((i.input_value for i in self.value_map if i != value))
+        layout.alert = value.input_value in other_input_values
+        layout.prop(value, "input_value", text="From")
+        layout.alert = False
+        layout.prop(value, "output_value", text="To")
+
+    def export(self, exporter: Exporter, bo: bpy.types.Object, so: plSceneObject):
+        input_variable = self.find_input("input_variable")
+        if input_variable is None:
+            self.raise_error("Must be linked to an input SDL variable")
+
+        output_variable = self.find_output("output_variable")
+        if output_variable is None:
+            self.raise_error("Must be linked to an output SDL variable")
+
+        # Ensure no states are duplicated. That would be bad.
+        counter = Counter((i for i, _ in self._iter_items()))
+        dupes = [str(state) for state, count in counter.items() if count > 1]
+        if dupes:
+            self.raise_error(
+                f"The following states are duplicated: '{f', '.join((str(i) for i in dupes))}'"
+            )
+
+        pfm = self._find_create_object(plPythonFileMod, exporter, so=so)
+        pfm.filename = "xAgeSDLVarSet"
+        self._add_py_parameter(pfm, 1, plPythonParameter.kString, input_variable.variable_name)
+        self._add_py_parameter(pfm, 2, plPythonParameter.kString, output_variable.variable_name)
+        self._add_py_parameter(
+            pfm, 3, plPythonParameter.kString,
+            "".join((f"({i},{j})" for i, j in self._iter_items()))
+        )
+        self._add_py_parameter(pfm, 4, plPythonParameter.kString, self.tag_string)
+
+    @property
+    def export_once(self):
+        return True
+
+    def _iter_items(self) -> Iterator[Tuple[int, int]]:
+        for i in self.value_map:
+            yield (i.input_value, i.output_value)
 
 
 class PlasmaSDLVariableNode(PlasmaNodeBase, bpy.types.Node):

--- a/korman/nodes/node_messages.py
+++ b/korman/nodes/node_messages.py
@@ -1043,25 +1043,26 @@ class PlasmaTimerCallbackMsgNode(PlasmaMessageWithCallbacksNode, bpy.types.Node)
 class PlasmaTriggerMultiStageMsgNode(PlasmaMessageNode, bpy.types.Node):
     bl_category = "MSG"
     bl_idname = "PlasmaTriggerMultiStageMsgNode"
-    bl_label = "Trigger MultiStage"
+    bl_label = "Trigger"
 
     output_sockets: dict[str, dict[str, Any]] = {
         "satisfies": {
             "text": "Trigger",
             "type": "PlasmaConditionSocket",
-            "valid_link_nodes": "PlasmaMultiStageBehaviorNode",
-            "valid_link_sockets": "PlasmaConditionSocket",
             "link_limit": 1,
         }
     }
 
     def convert_message(self, exporter, so):
-        # Yeah, this is not a REAL Plasma message, but the Korman way is to try to hide these little
-        # low-level notifications behind higher level abstractions, so here you go. A notify message
-        # that only targets plMultiStageBehMod. You're welcome!
+        # This node was designed to target only MultiStageBehaviors. In Plasma, to trigger an MSB,
+        # you send a collision notify from a Responder. If a collision event is not present in a
+        # plNotifyMsg, then the receivers are blown away and rewritten to be whoever triggered the
+        # Responder last. That means an MSB trigger "message" is really a generic "trigger some
+        # logic" message as well. So, use the generic code here. I've also relaxed the MSB linkage
+        # requirement so some of the new SDL change nodes can be triggered from here.
         msg = self.generate_notify_msg(exporter, so, "satisfies")
 
-        # The MultiStageBehMod needs to receive the avatar key that whatdonetriggeredit. We don't know
+        # A MultiStageBehMod needs to receive the avatar key that whatdonetriggeredit. We don't know
         # this information at export-time, but plResponderModifier::IContinueSending will interpret
         # a collision event as "ohey, let's add the avatar key for MSBs" - nice.
         msg.addEvent(proCollisionEventData())

--- a/korman/operators/op_ui.py
+++ b/korman/operators/op_ui.py
@@ -49,7 +49,8 @@ class CollectionAddOperator(UIOperator, bpy.types.Operator):
                                options=set())
 
     def execute(self, context):
-        props = getattr(context, self.context).path_resolve(self.group_path)
+        id_data = context.path_resolve(self.context) if "." in self.context else getattr(context, self.context)
+        props = id_data.path_resolve(self.group_path)
         collection = getattr(props, self.collection_prop)
         idx = len(collection)
         collection.add()
@@ -82,7 +83,8 @@ class CollectionRemoveOperator(UIOperator, bpy.types.Operator):
                                options=set())
 
     def execute(self, context):
-        props = getattr(context, self.context).path_resolve(self.group_path)
+        id_data = context.path_resolve(self.context) if "." in self.context else getattr(context, self.context)
+        props = id_data.path_resolve(self.group_path)
         collection = getattr(props, self.collection_prop)
         if self.index_prop:
             index = getattr(props, self.index_prop)

--- a/korman/ui/ui_list.py
+++ b/korman/ui/ui_list.py
@@ -79,7 +79,7 @@ def draw_list(layout, listtype, context_attr, prop_base, collection_name, index_
        - index_name: name of the active element index property
        - name_prefix: (optional) prefix to apply to display name of new elements
        - name_prop: (optional) property for each element's display name
-       *** any other arguments are passed as keyword arguments to the template_list call 
+       *** any other arguments are passed as keyword arguments to the template_list call
     """
     prop_path = prop_base.path_from_id()
     name_prefix = kwargs.pop("name_prefix", "")
@@ -104,3 +104,35 @@ def draw_list(layout, listtype, context_attr, prop_base, collection_name, index_
 
 def draw_modifier_list(layout, listtype, prop_base, collection_name, index_name, **kwargs):
     draw_list(layout, listtype, "object", prop_base, collection_name, index_name, **kwargs)
+
+def draw_node_list(
+    node: bpy.types.Node,
+    layout: bpy.types.UILayout,
+    collection_name: str,
+    draw_func: Callable[[Any, bpy.types.UILayout], None],
+    *,
+    header: str = "",
+    footer: str = "",
+) -> None:
+    """
+    Draws a simplified list for nodes. Nodes are much more compact in UI space than modifiers are,
+    so this won't use the traditional UIList. However, we will still use the helper operators we
+    all know and love.
+    """
+    if header:
+        layout.label(f"{header}:")
+
+    layout = layout.column(align=True)
+    for i, item in enumerate(getattr(node, collection_name)):
+        row = layout.row(align=True)
+        draw_func(item, row.row(align=True))
+        op = row.operator("ui.plasma_collection_remove", text="", icon="ZOOMOUT")
+        op.context = "space_data.node_tree"
+        op.group_path = node.path_from_id()
+        op.collection_prop = collection_name
+        op.manual_index = i
+
+    op = layout.operator("ui.plasma_collection_add", text=footer, icon="ZOOMIN")
+    op.context = "space_data.node_tree"
+    op.group_path = node.path_from_id()
+    op.collection_prop = collection_name


### PR DESCRIPTION
# Intro
This PR adds a set of logic nodes that can be used to more easily track the flow of execution and information. Almost all of these nodes export PythonFileMods under the hood. The Python File Nodes are great in that we have them, but it gets challenging when they are used with Responders because the flow control is inverted in that case - the responder node is an input to the PFM node and script, but the script can trigger the responder, meaning it should logically be an output. These nodes make it so that responders are outputs. See an example tree:

<img width="1560" height="1116" alt="image" src="https://github.com/user-attachments/assets/7d6d4de3-5cc3-4837-a938-77ce941ee111" />

This tree combines two different situations and should probably be separated in a real Age. The upper tree is the more complicated one. It shows a clickable that will only be possible to click when the `Rm02BtnEnabled` SDL variable is set to true. When the clickable is pressed, the `Rm02SpinTorus` SDL boolean is toggled. When `Rm02SpinTorus` is true, the animation attached to the `Rm02Torus` object plays. When the variable is false, the same animation stops. This is the proper way to design logic interactions in the game to synchronize among multiple clients correctly, and the flow is quite clear IMO.

The bottom tree is an exercise for you, the viewer, to figure out. Be advised, although the "SDL Clickable" node is shown in the image above and described in the text above has actually been removed from this PR due to some design concerns. I will open a separate PR with that node and describe the design concerns there soon.

I do not have a demo blend to share at this time, so here is a list of the nodes added and the Python files they use in commit order. I may make a few more minor adjustments to this to ensure that some in-node lists start populated, but the code is otherwise complete, IMO. This is the follow-up promised in #449, and I expect I will want to merge this one shortly after it. Feedback needs to be prompt.

# Nodes
## Logic > SDL Variable
This just holds an SDL variable's name and shows logic flow. It doesn't actually export anything. 
<img width="228" height="125" alt="image" src="https://github.com/user-attachments/assets/ab74a7e7-1b1d-4163-a4fb-a189dc520ab5" />

## Logic > Change SDL
Changes an SDL value when notified.
Files: xAgeSDLBoolToggle, xAgeSDLBoolSet, xAgeSDLIntChange
<img width="415" height="140" alt="image" src="https://github.com/user-attachments/assets/ed0ffa7c-3fe1-444f-b15a-2b0746ff17dd" />

## Logic > SDL Boolean Trigger
Trigger a responder when an SDL bool changes
Files: xAgeSDLBoolRespond, xAgeSDLBoolAndRespond
<img width="177" height="172" alt="image" src="https://github.com/user-attachments/assets/ca5847c3-3eb8-4950-b613-5a0ced4bbf2d" />

## Conditions > SDL Boolean Condition
Gates the firing of some other condition behind an SDL variable. Doesn't enable/disable the attached condition.
File: xAgeSDLBoolCondResp
<img width="168" height="156" alt="image" src="https://github.com/user-attachments/assets/20423c85-333a-4c16-b870-669e0437ec40" />

## Logic > SDL Boolean Gate
Takes >=2 SDL variables as inputs and performs either a logical AND, OR, XOR, or NAND on them, storing the result in an output variable.
Filenames: xAgeSDLBoolAndSet, xAgeSDLBoolGateSet
<img width="147" height="192" alt="image" src="https://github.com/user-attachments/assets/da0236fc-11dc-4fd2-b2d4-b53cd766f652" />

## Logic > SDL Value Map
Uses an in-node lookup table to set the output variable value from the input variable value.
File: xAgeSDLVarSet
<img width="246" height="167" alt="image" src="https://github.com/user-attachments/assets/4d679a26-5687-4401-869a-18d7af9873e0" />

## Logic > SDL Integer Trigger
Fires specific responder states based on an SDL int value.
File: xAgeSDLIntStateListResp
<img width="496" height="223" alt="image" src="https://github.com/user-attachments/assets/0cdb049c-c1c0-4c05-a058-a4cb7fb74f47" />

 ## Logic > SDL Value Trigger
This is like SDL Boolean Trigger, except for a set of specific integer values.
File: xAgeSDLIntStartStopResp
<img width="173" height="236" alt="image" src="https://github.com/user-attachments/assets/b4a7caf0-54a4-495b-b232-48541c43d2a6" />

## Bonus Chatter
Also, in order to "convert" from being inside of a Responder to triggering the Change SDL node, the "Trigger MultiStage" message node has been renamed to just "Trigger". The "Trigger" node can trigger a MultStage or any condition... such as Change SDL. This will be a powerful way to set SDL variables at specific points during responders, eg on a oneshot marker ("DoorButtonTouch" anyone?).