### PR TITLE
Image Compression Improvements

### DIFF
--- a/korman/exporter/image.py
+++ b/korman/exporter/image.py
@@ -48,6 +48,7 @@ class _EntryBits(enum.IntEnum):
     last_export = 6
     image_count = 7
     tag_string = 8
+    quality = 9
 
 
 class _CachedImage:
@@ -63,6 +64,7 @@ class _CachedImage:
         self.modify_time = None
         self.image_count = 1
         self.tag = None
+        self.quality = None
 
     def __str__(self):
         return self.name
@@ -75,7 +77,7 @@ class ImageCache:
         self._read_stream = hsFileStream()
         self._stream_handles = 0
 
-    def add_texture(self, texture, num_levels, export_size, compression, images):
+    def add_texture(self, texture, num_levels, export_size, compression, quality, images):
         image, tag = texture.image, texture.tag
         image_name = str(texture)
         key = (image_name, tag, compression)
@@ -96,6 +98,7 @@ class ImageCache:
         image.image_data = images
         image.image_count = len(images)
         image.tag = tag
+        image.quality = quality
         self._images[key] = image
 
     def _compact(self):
@@ -116,7 +119,7 @@ class ImageCache:
         if self._stream_handles == 0:
             self._read_stream.close()
 
-    def get_from_texture(self, texture, compression):
+    def get_from_texture(self, texture, compression, quality):
         bl_image, tag = texture.image, texture.tag
 
         # If the texture is ephemeral (eg a lightmap) or has been marked "rebuild" or "skip"
@@ -135,6 +138,12 @@ class ImageCache:
         # ensure the texture key generally matches up with our copy of this image.
         # if not, a recache will likely be triggered implicitly.
         if tuple(bl_image.size) != cached_image.source_size:
+            return None
+
+        # quality must be an exact match.
+        # not using this as part of the image key to avoid accumulating different
+        # version of the same image that differ only by a few points of compression.
+        if cached_image.quality != quality:
             return None
 
         # if the image is on the disk, we can check the its modify time for changes
@@ -274,6 +283,8 @@ class ImageCache:
         if flags[_EntryBits.tag_string]:
             # tags should not contain user data, so we will use a latin_1 backed string
             image.tag = stream.readSafeStr()
+        if flags[_EntryBits.quality]:
+            image.quality = stream.readByte()
 
         # do we need to check for duplicate images?
         self._images[(image.name, image.tag, image.compression)] = image
@@ -354,6 +365,7 @@ class ImageCache:
         flags[_EntryBits.last_export] = True
         flags[_EntryBits.image_count] = True
         flags[_EntryBits.tag_string] = image.tag is not None
+        flags[_EntryBits.quality] = image.quality is not None
 
         stream.write(_ENTRY_MAGICK)
         flags.write(stream)
@@ -369,3 +381,5 @@ class ImageCache:
         stream.writeInt(image.image_count)
         if image.tag is not None:
             stream.writeSafeStr(image.tag)
+        if image.quality is not None:
+            stream.writeByte(image.quality)

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -34,6 +34,7 @@ from ..korlib import *
 from . import utils
 
 if TYPE_CHECKING:
+    from .convert import Exporter
     from .manager import ExportManager
 
 _MAX_STENCILS = 6
@@ -141,7 +142,7 @@ class _Texture:
 
 
 class MaterialConverter:
-    def __init__(self, exporter):
+    def __init__(self, exporter: Exporter):
         self._obj2mat = defaultdict(dict)
         self._obj2layer = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         self._bump_mats = {}

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -104,6 +104,8 @@ class _Texture:
         self.image = image
         self.tag = kwargs.get("tag", None)
         self.name = kwargs.get("name", image.name)
+        self.dxt_quality = kwargs.get("dxt_quality", plMipmap.kBlockQualityHigh)
+        self.jpeg_quality = kwargs.get("jpeg_quality", 70)
 
     def __eq__(self, other):
         if not isinstance(other, _Texture):
@@ -140,6 +142,10 @@ class _Texture:
             self.alpha_type = other.alpha_type
         if other.mipmap:
             self.mipmap = True
+        if self.dxt_quality < other.dxt_quality:
+            self.dxt_quality = other.dxt_quality
+        if self.jpeg_quality < other.jpeg_quality:
+            self.jpeg_quality = other.jpeg_quality
 
 
 class MaterialConverter:
@@ -1088,6 +1094,10 @@ class MaterialConverter:
                              same name to coexist in the cache
            - is_cube_map: (optional) indicates the provided image contains six cube faces
                                      that must be split into six separate images for Plasma
+           - dxt_quality: (optional) the minimum DXT compression quality that should be used
+                                     for this image, defaults to kBlockQualityHigh
+           - jpeg_quality: (optional) the minimum JPEG compression quality that should be used
+                                      for this image, defaults to 70
         """
         owner = kwargs.pop("owner", None)
         key = _Texture(**kwargs)
@@ -1135,11 +1145,19 @@ class MaterialConverter:
                         raise ValueError(allowed_formats)
                     dxt = plBitmap.kDXT5 if key.alpha_type == TextureAlpha.full else plBitmap.kDXT1
 
+                    # The DXT and JPEG quality numbers don't really mean the same thing.
+                    if compression == plBitmap.kDirectXCompression:
+                        quality = key.dxt_quality
+                    elif compression == plBitmap.kJPEGCompression:
+                        quality = key.jpeg_quality
+                    else:
+                        quality = None
+
                     # Mayhaps we have a cached version of this that has already been exported
-                    cached_image = texcache.get_from_texture(key, compression)
+                    cached_image = texcache.get_from_texture(key, compression, quality)
 
                     if cached_image is None:
-                        numLevels, width, height, data = self._finalize_cache(texcache, key, image, name, compression, dxt)
+                        numLevels, width, height, data = self._finalize_cache(texcache, key, image, name, compression, dxt, quality)
                         self._finalize_bitmap(key, owners, name, numLevels, width, height, compression, dxt, data)
                     else:
                         width, height = cached_image.export_size
@@ -1152,7 +1170,7 @@ class MaterialConverter:
                             self._finalize_bitmap(key, owners, name, numLevels, width, height, compression, dxt, data)
                         except RuntimeError:
                             self._report.warn("Cached image is corrupted! Recaching image...")
-                            numLevels, width, height, data = self._finalize_cache(texcache, key, image, name, compression, dxt)
+                            numLevels, width, height, data = self._finalize_cache(texcache, key, image, name, compression, dxt, quality)
                             self._finalize_bitmap(key, owners, name, numLevels, width, height, compression, dxt, data)
 
                 inc_progress()
@@ -1184,6 +1202,12 @@ class MaterialConverter:
                             for i in range(numLevels):
                                 mipmap.setLevel(i, face_data[i])
                             setattr(texture, face_name, mipmap)
+                    elif compression == plBitmap.kJPEGCompression and len(data) == 3:
+                        assert numLevels == 1
+                        mipmap.setRawImage(data[0][0])
+                        mipmap.setImageJPEG(data[1][0])
+                        mipmap.setAlphaJPEG(data[2][0])
+                        texture = mipmap
                     else:
                         assert len(data) == 1
                         for i in range(numLevels):
@@ -1205,15 +1229,15 @@ class MaterialConverter:
                 else:
                     raise NotImplementedError(owner.ClassName())
 
-    def _finalize_cache(self, texcache, key, image, name, compression, dxt):
+    def _finalize_cache(self, texcache, key, image, name, compression, dxt, quality):
         if key.is_cube_map:
-            numLevels, width, height, data = self._finalize_cube_map(key, image, name, compression, dxt)
+            numLevels, width, height, data = self._finalize_cube_map(key, image, name, compression, dxt, quality)
         else:
-            numLevels, width, height, data = self._finalize_single_image(key, image, name, compression, dxt)
-        texcache.add_texture(key, numLevels, (width, height), compression, data)
+            numLevels, width, height, data = self._finalize_single_image(key, image, name, compression, dxt, quality)
+        texcache.add_texture(key, numLevels, (width, height), compression, quality, data)
         return numLevels, width, height, data
 
-    def _finalize_cube_map(self, key, image, name, compression, dxt):
+    def _finalize_cube_map(self, key, image, name, compression, dxt, quality):
         oWidth, oHeight = image.size
         if oWidth == 0 and oHeight == 0:
             raise ExportError(f"Image '{image.name}' could not be loaded.")
@@ -1272,23 +1296,57 @@ class MaterialConverter:
                 numLevels = 1
                 self._report.msg(f"Compressing single level for cube face '{name}'")
 
-            if compression == plBitmap.kDirectXCompression:
-                # If we're compressing this mofo, we'll need a temporary mipmap to do that here...
-                mipmap = plMipmap(
-                    name=name, width=eWidth, height=eHeight, numLevels=numLevels,
-                    compType=compression, format=plBitmap.kRGB8888, dxtLevel=dxt
-                )
-
-            face_images[i] = [None] * numLevels
-            for j in range(numLevels):
-                level_data = glimage.get_level_data(j, key.calc_alpha, report=self._report)
-                if compression == plBitmap.kDirectXCompression:
-                    mipmap.CompressImage(j, level_data)
-                    level_data = mipmap.getLevel(j)
-                face_images[i][j] = level_data
+            # Assumption: There will never be a JPEG compressed cube map - jpeg compression
+            # uses multiple images to smuggle the cached JPEG data through. That's the
+            # same trick we use to smuggle cube faces through the cache, so it's mutually
+            # exclusive.
+            assert compression != plBitmap.kJPEGCompression, "Cubemaps cannot be JPEG compressed"
+            # Take the first image from this - we're building our own smuggle list.
+            face_images[i] = self._finalize_generic_image(
+                key, glimage, eWidth, eHeight, compression, dxt, quality, numLevels
+            )[0]
         return numLevels, eWidth, eHeight, face_images
 
-    def _finalize_single_image(self, key, image, name, compression, dxt):
+    def _finalize_generic_image(
+        self,
+        key: _Texture,
+        glimage: GLTexture,
+        width: int,
+        height: int,
+        compression: int,
+        dxt: int,
+        quality: int,
+        numLevels: int
+    ) -> List[List[bytes]]:
+        # The most common case is allocating for DXT, so this is fine to be unconditional.
+        mipmap = plMipmap(
+            name="TEMP", width=width, height=height, numLevels=numLevels,
+            compType=compression, format=plBitmap.kRGB8888, dxtLevel=dxt
+        )
+        data = []
+        for i in range(numLevels):
+            level_data = glimage.get_level_data(i, key.calc_alpha, report=self._report)
+            if compression == plBitmap.kDirectXCompression:
+                mipmap.CompressImage(i, level_data, quality)
+                if not data:
+                    data.append([])
+                data[0].append(mipmap.getLevel(i))
+            elif compression == plBitmap.kJPEGCompression:
+                assert numLevels == 1
+                mipmap.setRawImage(level_data)
+                mipmap.CompressJPEG(quality)
+                data.extend([
+                    [level_data],
+                    [mipmap.jpegImage],
+                    [mipmap.jpegAlpha]
+                ])
+            else:
+                if not data:
+                    data.append([])
+                data[0].append(level_data)
+        return data
+
+    def _finalize_single_image(self, key, image, name, compression, dxt, quality):
         oWidth, oHeight = image.size
         if oWidth == 0 and oHeight == 0:
             raise ExportError("Image '{}' could not be loaded.".format(image.name))
@@ -1306,25 +1364,10 @@ class MaterialConverter:
                 numLevels = 1
                 self._report.msg("Compressing single level")
 
-            if compression == plBitmap.kDirectXCompression:
-                # If this is a DXT-compressed mipmap, we need to use a temporary mipmap
-                # to do the compression. We'll then steal the data from it. We're doing
-                # this outside of the loop to only allocate once.
-                mipmap = plMipmap(
-                    name=name, width=eWidth, height=eHeight, numLevels=numLevels,
-                    compType=compression, format=plBitmap.kRGB8888, dxtLevel=dxt
-                )
-
-            # Hold the uncompressed level data for now. We may have to make multiple copies of
-            # this mipmap for per-page textures :(
-            data = [None] * numLevels
-            for i in range(numLevels):
-                level_data = glimage.get_level_data(i, key.calc_alpha, report=self._report)
-                if compression == plBitmap.kDirectXCompression:
-                    mipmap.CompressImage(i, level_data)
-                    level_data = mipmap.getLevel(i)
-                data[i] = level_data
-        return numLevels, eWidth, eHeight, [data,]
+            data = self._finalize_generic_image(
+                key, glimage, eWidth, eHeight, compression, dxt, quality, numLevels
+            )
+        return numLevels, eWidth, eHeight, data
 
     def get_materials(self, bo: bpy.types.Object, bm: Optional[bpy.types.Material] = None) -> Iterator[plKey[hsGMaterial]]:
         material_dict = self._obj2mat.get(bo, {})

--- a/korman/exporter/material.py
+++ b/korman/exporter/material.py
@@ -59,12 +59,13 @@ class _Texture:
             if image is None:
                 image = texture.image
             self.calc_alpha = getattr(texture, "use_calculate_alpha", False)
-            self.mipmap = texture.use_mipmap
+            self.mipmap = kwargs.get("mipmap", texture.use_mipmap)
         else:
             self.layer = kwargs.get("layer")
             self.calc_alpha = False
             self.mipmap = kwargs.get("mipmap", False)
 
+        plasma_image = image.plasma_image
         if kwargs.get("is_detail_map", False):
             self.is_detail_map = True
             self.mipmap = True
@@ -85,7 +86,7 @@ class _Texture:
             else:
                 self.alpha_type = kwargs.get("alpha_type", TextureAlpha.opaque)
             self.allowed_formats = kwargs.get("allowed_formats",
-                                              {"DDS"} if self.mipmap else {"PNG", "JPG"})
+                                              {"DDS"} if plasma_image.allow_dds else {"PNG", "JPG"})
             self.is_cube_map = kwargs.get("is_cube_map", False)
 
         # Basic format sanity
@@ -94,7 +95,7 @@ class _Texture:
 
         if len(self.allowed_formats) == 1:
             self.auto_ext = next(iter(self.allowed_formats)).lower()
-        elif self.mipmap:
+        elif "DDS" in self.allowed_formats:
             self.auto_ext = "dds"
         else:
             self.auto_ext = "hsm"
@@ -298,8 +299,10 @@ class MaterialConverter:
             layer.ambient = hsColorRGBA(0.0, 0.0, 0.0, 1.0)
             layer.preshade = hsColorRGBA(0.0, 0.0, 0.0, 1.0)
             layer.runtime = hsColorRGBA(1.0, 1.0, 1.0, 1.0)
-            self.export_prepared_image(name=image_name, image=image, alpha_type=image_alpha,
-                                       owner=layer, allowed_formats={"DDS"})
+            self.export_prepared_image(
+                name=image_name, image=image, alpha_type=image_alpha,
+                owner=layer, allowed_formats={"DDS"}, mipmap=True
+            )
             material = self._mgr.add_object(hsGMaterial, bl=bo, name=name)
             material.addLayer(layer.key)
             return material, layer
@@ -919,6 +922,8 @@ class MaterialConverter:
             dtm.visHeight = int(layer_props.dynatext_resolution)
             layer.texture = dtm.key
         else:
+            plasma_image = texture.image.plasma_image
+
             detail_blend = TEX_DETAIL_ALPHA
             if layer_props.is_detail_map and mipmap:
                 if slot.blend_type == "ADD":
@@ -930,7 +935,17 @@ class MaterialConverter:
             if layer_props.is_detail_map and not state.blendFlags & hsGMatState.kBlendMask:
                 state.blendFlags |= hsGMatState.kBlendDetail
 
-            allowed_formats = {"DDS"} if mipmap else {"PNG", "BMP"}
+            if not layer_props.is_detail_map and not plasma_image.allow_dds:
+                allowed_formats = {"BMP", "PNG"}
+                if mipmap:
+                    self._report.warn(
+                        f"Image '{texture.image.name}' does not allow DXT compression, so "
+                        f"mipmapping will be forced OFF for texture '{texture.name}'"
+                    )
+                    mipmap = False
+            else:
+                allowed_formats = {"DDS"}
+
             self.export_prepared_image(texture=texture, owner=layer,
                                        alpha_type=alpha_type, force_calc_alpha=slot.use_stencil,
                                        is_detail_map=layer_props.is_detail_map,
@@ -1108,18 +1123,16 @@ class MaterialConverter:
 
                     # Now we try to use the pile of hints we were given to figure out what format to use
                     allowed_formats = key.allowed_formats
-                    if key.mipmap:
+                    if "DDS" in allowed_formats:
                         compression = plBitmap.kDirectXCompression
                     elif "PNG" in allowed_formats and self._mgr.getVer() == pvMoul:
                         compression = plBitmap.kPNGCompression
-                    elif "DDS" in allowed_formats:
-                        compression = plBitmap.kDirectXCompression
                     elif "JPG" in allowed_formats:
                         compression = plBitmap.kJPEGCompression
                     elif "BMP" in allowed_formats:
                         compression = plBitmap.kUncompressed
                     else:
-                        raise RuntimeError(allowed_formats)
+                        raise ValueError(allowed_formats)
                     dxt = plBitmap.kDXT5 if key.alpha_type == TextureAlpha.full else plBitmap.kDXT1
 
                     # Mayhaps we have a cached version of this that has already been exported
@@ -1252,16 +1265,19 @@ class MaterialConverter:
             glimage.image_data = fWidth, fHeight, face_images[i]
             eWidth, eHeight = glimage.size_pot
             name = face_name[:-4].upper()
-            if compression == plBitmap.kDirectXCompression:
+            if compression == plBitmap.kDirectXCompression and key.mipmap:
                 numLevels = glimage.num_levels
-                self._report.msg("Generating mip levels for cube face '{}'", name)
-
-                # If we're compressing this mofo, we'll need a temporary mipmap to do that here...
-                mipmap = plMipmap(name=name, width=eWidth, height=eHeight, numLevels=numLevels,
-                                  compType=compression, format=plBitmap.kRGB8888, dxtLevel=dxt)
+                self._report.msg(f"Generating mip levels for cube face '{name}'")
             else:
                 numLevels = 1
-                self._report.msg("Compressing single level for cube face '{}'", name)
+                self._report.msg(f"Compressing single level for cube face '{name}'")
+
+            if compression == plBitmap.kDirectXCompression:
+                # If we're compressing this mofo, we'll need a temporary mipmap to do that here...
+                mipmap = plMipmap(
+                    name=name, width=eWidth, height=eHeight, numLevels=numLevels,
+                    compType=compression, format=plBitmap.kRGB8888, dxtLevel=dxt
+                )
 
             face_images[i] = [None] * numLevels
             for j in range(numLevels):
@@ -1283,17 +1299,21 @@ class MaterialConverter:
         # Grab the image data from OpenGL and stuff it into the plBitmap
         with GLTexture(key, bgra=bgra) as glimage:
             eWidth, eHeight = glimage.size_pot
-            if compression == plBitmap.kDirectXCompression:
+            if compression == plBitmap.kDirectXCompression and key.mipmap:
                 numLevels = glimage.num_levels
                 self._report.msg("Generating mip levels")
-
-                # If this is a DXT-compressed mipmap, we need to use a temporary mipmap
-                # to do the compression. We'll then steal the data from it.
-                mipmap = plMipmap(name=name, width=eWidth, height=eHeight, numLevels=numLevels,
-                                  compType=compression, format=plBitmap.kRGB8888, dxtLevel=dxt)
             else:
                 numLevels = 1
                 self._report.msg("Compressing single level")
+
+            if compression == plBitmap.kDirectXCompression:
+                # If this is a DXT-compressed mipmap, we need to use a temporary mipmap
+                # to do the compression. We'll then steal the data from it. We're doing
+                # this outside of the loop to only allocate once.
+                mipmap = plMipmap(
+                    name=name, width=eWidth, height=eHeight, numLevels=numLevels,
+                    compType=compression, format=plBitmap.kRGB8888, dxtLevel=dxt
+                )
 
             # Hold the uncompressed level data for now. We may have to make multiple copies of
             # this mipmap for per-page textures :(

--- a/korman/properties/modifiers/gui.py
+++ b/korman/properties/modifiers/gui.py
@@ -54,14 +54,32 @@ _DEFAULT_LANGUAGE_ID = 1
 
 
 class ImageLibraryItem(bpy.types.PropertyGroup):
-    image = bpy.props.PointerProperty(name="Image Item",
-                                      description="Image stored for export.",
-                                      type=bpy.types.Image,
-                                      options=set())
-    enabled = bpy.props.BoolProperty(name="Enabled",
-                                     description="Specifies whether this image will be stored during export.",
-                                     default=True,
-                                     options=set())
+    image = PointerProperty(
+        name="Image Item",
+        description="Image stored for export.",
+        type=bpy.types.Image,
+        options=set()
+    )
+    enabled = BoolProperty(
+        name="Enabled",
+        description="Specifies whether this image will be stored during export.",
+        default=True,
+        options=set()
+    )
+
+    compress = BoolProperty(
+        name="Compress",
+        description="Allow using lossy compression on disk",
+        default=True,
+        options=set()
+    )
+    quality = IntProperty(
+        name="Quality",
+        description="Compression quality",
+        min=0, max=100, default=70,
+        subtype="PERCENTAGE",
+        options=set()
+    )
 
     # UI Thunk
     def _get_name(self) -> str:
@@ -88,7 +106,14 @@ class PlasmaImageLibraryModifier(PlasmaModifierProperties):
 
             for item in self.images:
                 if item.image and item.enabled:
-                    exporter.mesh.material.export_prepared_image(owner=ilmod, image=item.image, allowed_formats={"JPG", "PNG"}, extension="hsm")
+                    allowed_formats = {"JPG"} if item.compress else {"BMP", "PNG"}
+                    exporter.mesh.material.export_prepared_image(
+                        owner=ilmod,
+                        image=item.image,
+                        allowed_formats=allowed_formats,
+                        jpeg_quality=item.quality,
+                        extension="hsm"
+                    )
 
 
 class TranslationItem:
@@ -440,8 +465,14 @@ class PlasmaLinkingBookModifier(PlasmaModifierProperties, PlasmaModifierLogicWiz
             user_images = (i for i in (self.book_cover_image, self.link_panel_image, self.stamp_image)
                            if i is not None)
             for image in user_images:
-                exporter.mesh.material.export_prepared_image(owner=ilmod, image=image,
-                                                             allowed_formats={"JPG", "PNG"}, extension="hsm")
+                # Cyan always uses JPEGs in their Ages for this, so just force everything
+                # to a 70% JPEG to match. If the artist doesn't like it, they can wire
+                # up something better themselves.
+                exporter.mesh.material.export_prepared_image(
+                    owner=ilmod, image=image,
+                    allowed_formats={"JPG"},
+                    extension="hsm"
+                )
 
     def harvest_actors(self):
         if self.seek_point is not None:

--- a/korman/properties/modifiers/render.py
+++ b/korman/properties/modifiers/render.py
@@ -422,15 +422,28 @@ class PlasmaLightMapGen(idprops.IDPropMixin, PlasmaModifierProperties, PlasmaMod
 
     deprecated_properties = {"render_layers"}
 
-    quality = EnumProperty(name="Quality",
-                           description="Resolution of lightmap",
-                           items=[
-                                  ("128", "128px", "128x128 pixels"),
-                                  ("256", "256px", "256x256 pixels"),
-                                  ("512", "512px", "512x512 pixels"),
-                                  ("1024", "1024px", "1024x1024 pixels"),
-                                  ("2048", "2048px", "2048x2048 pixels"),
-                            ])
+    quality = EnumProperty(
+        name="Quality",
+        description="Resolution of lightmap",
+        items=[
+            ("128", "128px", "128x128 pixels"),
+            ("256", "256px", "256x256 pixels"),
+            ("512", "512px", "512x512 pixels"),
+            ("1024", "1024px", "1024x1024 pixels"),
+            ("2048", "2048px", "2048x2048 pixels"),
+        ],
+        options=set()
+    )
+    compression_strategy = EnumProperty(
+        name="Compression",
+        description="",
+        items=[
+            ("AUTO", "[Auto]", "Let Korman decide whether the lightmap should be compressed in video memory"),
+            ("LOSSLESS", "Lossless", "Never compress the lightmap in video memory"),
+            ("LOSSY", "Lossy", "Always compress the lightmap in video memory"),
+        ],
+        options=set()
+    )
 
     bake_type = EnumProperty(name="Bake To",
                              description="Destination for baked lighting data",
@@ -500,6 +513,19 @@ class PlasmaLightMapGen(idprops.IDPropMixin, PlasmaModifierProperties, PlasmaMod
         if uvw_src is None:
             raise ExportError("'{}': Lightmap UV Texture '{}' seems to be missing. Did you delete it?", bo.name, uvtex_name)
 
+        # Some Ages use "excessive" lightmaps - stuff that's 1024x1024 and the object in
+        # question is just not that big. So, by default, let's DXT compress anything 256x256
+        # or larger. That way, the VRAM impact is less dramatic for large lightmaps.
+        # If the compression sucks enough, the artist can manually turn off the compression.
+        if self.compression_strategy == "AUTO" and max(lightmap_im.size) >= 256:
+            allowed_formats = {"DDS"}
+        elif self.compression_strategy in {"AUTO", "LOSSLESS"}:
+            allowed_formats = {"BMP", "PNG"}
+        elif self.compression_strategy == "LOSSY":
+            allowed_formats = {"DDS"}
+        else:
+            raise ValueError(self.compression_strategy)
+
         for matKey in materials:
             layer = exporter.mgr.add_object(plLayer, name="{}_LIGHTMAPGEN".format(matKey.name), so=so)
             layer.UVWSrc = uvw_src
@@ -520,11 +546,20 @@ class PlasmaLightMapGen(idprops.IDPropMixin, PlasmaModifierProperties, PlasmaMod
             mat.compFlags |= hsGMaterial.kCompIsLightMapped
             mat.addPiggyBack(layer.key)
 
-            # Mmm... cheating
-            mat_mgr.export_prepared_image(owner=layer, image=lightmap_im,
-                                          allowed_formats={"PNG", "JPG"},
-                                          extension="hsm",
-                                          ephemeral=True)
+            # Pass the image basically as is to the texture code and let it figure out
+            # what in the world do to with this. Since this is a lightmap, if they've asked
+            # for it to be DXT compressed, we're going to request no mipmapping and ultra
+            # quality processing. Mipmapped LMs are nonsense, and we want the ultra processing
+            # to help keep gradients as smooth as possible.
+            # TODO: We should probably try to cache these images - kBlockQualityUltra is slow.
+            mat_mgr.export_prepared_image(
+                owner=layer, image=lightmap_im,
+                allowed_formats=allowed_formats,
+                extension="hsm",
+                ephemeral=True,
+                mipmap=False,
+                dxt_quality=plMipmap.kBlockQualityUltra,
+            )
 
     @classmethod
     def _idprop_mapping(cls):

--- a/korman/properties/prop_image.py
+++ b/korman/properties/prop_image.py
@@ -24,3 +24,10 @@ class PlasmaImage(bpy.types.PropertyGroup):
                                           ("rebuild", "Refresh Image Cache", "Forces this image to be recached on the next export.")],
                                    default="use",
                                    options=set())
+
+    allow_dds = BoolProperty(
+        name="Compress",
+        description="Allow lossy compression in video memory",
+        default=True,
+        options=set()
+    )

--- a/korman/ui/modifiers/gui.py
+++ b/korman/ui/modifiers/gui.py
@@ -28,9 +28,20 @@ class ImageListUI(ui_list.PlasmaUIListBase[gui_mods.ImageLibraryItem], bpy.types
 def imagelibmod(modifier, layout, context):
     ui_list.draw_modifier_list(layout, "ImageListUI", modifier, "images", "active_image_index", rows=3, maxrows=6)
 
-    if modifier.images:
-        row = layout.row(align=True)
-        row.template_ID(modifier.images[modifier.active_image_index], "image", open="image.open")
+    try:
+        image = modifier.images[modifier.active_image_index]
+    except:
+        pass
+    else:
+        col = layout.column()
+        row = col.row(align=True)
+        row.template_ID(image, "image", open="image.open")
+
+        row = col.row(align=True)
+        row.prop(image, "compress", text="")
+        row = row.row(align=True)
+        row.active = image.compress
+        row.prop(image, "quality", text="Compression Quality")
 
 def journalbookmod(modifier, layout, context):
     layout.prop_menu_enum(modifier, "versions")

--- a/korman/ui/modifiers/render.py
+++ b/korman/ui/modifiers/render.py
@@ -228,6 +228,12 @@ def lightmap(modifier, layout, context):
     col = layout.column()
     col.active = is_texture
     col.prop(modifier, "quality")
+
+    # The rows would be smooshed together if we don't bail out of the previous column.
+    col = layout.column()
+    col.active = is_texture
+    col.prop(modifier, "compression_strategy")
+
     layout.prop_search(modifier, "bake_pass_name", pl_scene, "bake_passes", icon="RENDERLAYERS")
     layout.prop(modifier, "lights")
     col = layout.column()

--- a/korman/ui/ui_image.py
+++ b/korman/ui/ui_image.py
@@ -23,3 +23,4 @@ class PlasmaImageEditorHeader(bpy.types.Header):
         if image is not None:
             settings = image.plasma_image
             layout.prop(settings, "texcache_method", text="")
+            layout.prop(settings, "allow_dds", text="Compress", icon="PACKAGE")


### PR DESCRIPTION
This is something of a grab-bag of improvements to the way images are exported. The onus for this change is that a recent update to GoMePubNew caused some complains of crashing, which we traced back to too much VRAM being used. Many fan Ages export lightmaps that are quite huge. Currently, Korman exports lightmaps as PNGs or RLE JPEGs, which means lightmaps are uncompressed in VRAM. To improve the VRAM usage, any lightmap 256x256 or greater in resolution will be compressed as a single level DXT1 texture. This should greatly improve the VRAM efficiency of lightmaps at the cost of slightly more disk space being used. This can be overridden using a new "Compression" option on the lightmap modifier.

To enable this change, I needed to remove the association Korman currently has where the "MipMap" button on the Blender Texture indicates both "export mip levels" *and* "compress to DXT". The "MipMap" button now only indicates "export mip levels". Compression options are now exposed on the image datablock and on image libraries.

Considering that lightmaps often have smooth gradients, I added the ability for Korman to internally set the squish color fit method used for DXT. Lightmaps use the slow `kBlockQualityUltra` to hopefully not impact the quality too much. Normal textures have been bumped to `kBlockQualityHigh`, which is actually libsquish's default compressor. It's noticeably slower than libHSPlasma's default. When textures are exported after this is merged, any textures over 512x512 will be noticeably slower the first time they are exported. The good news is that the texture cache will hit from then on, making this a one time expense for a potentially higher in game quality. When Korman was written, I don't think PyHSPlasma allowed setting the block quality, so this is really just paying the piper.

To hopefully balance out the disk space concern, I have added the ability for Korman to actually compress JPEGs for images used in ImageLibMods. This is now the default. Previously, any "JPEG" exported by Korman was just an RLE bitmap. Now, we will use the same JPEG/RLE logic that Cyan uses. This does mean that "uncompressed" lightmaps (and uncompressed images in general) can no longer be RLE maps. Instead, they will simply be PNGs or uncompressed bitmaps.

After exporting a recent-ish version of GoMePubNew, I found that these changes decreases the total potential image memory requirement of the Age from 406 MiB to 250 MiB. Actual VRAM usage is lower for both of those because the number includes journal images, which are not loaded into VRAM.

Future work would be to implement something like #429, but this is a good start.